### PR TITLE
Make "state machine" approach the main Stage 2 thrust

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -19,7 +19,7 @@ module Main where
   import Ra ( pat_match, reduce )
   import Ra.GHC ( bind_to_table )
   import Ra.Lang ( SymTable, Sym(..), SymApp(..), StackBranch(..), unSB, Stack(..), ReduceSyms(..), PatMatchSyms(..), Write(..) )
-  import Ra.Lang.Extra ( ppr_sa )
+  import Ra.Lang.Extra ( ppr_sa, ppr_rs )
 
   import Outputable ( Outputable, interppSP, showSDocUnsafe, showPpr )
 
@@ -57,18 +57,20 @@ module Main where
               }) . unLoc) tl_binds
       -- return $ show $ map (M.mapKeys ppr . M.map (map toConstr) . snd) initial_branch
       -- pure ()
-      return $ uncurry (++) $ (
-          concatMap (
-              (++"\n") . ppr_sa (showPpr dflags)
-            )
-          . rs_syms &&& concatMap (
-            (++"\n")
-            . ppr_sa (showPpr dflags)
-            . w_sym)
-          . concat
-          . M.elems
-          . rs_writes
-        ) $ reduce initial_table $ (expr $ sa_sym $ head $ (!!1) $ M.elems $ initial_table)
+      -- return $ uncurry (++) $ (
+      --     concatMap (
+      --         (++"\n") . ppr_sa (showPpr dflags)
+      --       )
+      --     . rs_syms &&& concatMap (
+      --       (++"\n")
+      --       . ppr_sa (showPpr dflags)
+      --       . w_sym)
+      --     . concat
+      --     . M.elems
+      --     . rs_writes
+      --   ) $ reduce initial_table $ (expr $ sa_sym $ head $ (!!1) $ M.elems $ initial_table)
+      
+      return $ ppr_rs (showPpr dflags) $ reduce initial_table $ (expr $ sa_sym $ head $ (!!1) $ M.elems $ initial_table)
       
       -- return $ show $ map (show_sym dflags) $ concatMap (flip (reduce_deep $ [(noSrcSpan, SymTable $ unionsWith (++) $ map (bind_to_table ([(noSrcSpan, SymTable M.empty)]) . unLoc) $ bagToList (typecheckedSource t))]) []) ((concat $ shallowest cast (last $ bagToList (typecheckedSource t))) :: [HsExpr GhcTc])
       

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -18,7 +18,7 @@ module Main where
   
   import Ra ( pat_match, reduce )
   import Ra.GHC ( bind_to_table )
-  import Ra.Lang ( SymTable, Sym(..), SymApp(..), StackBranch(..), unSB, Stack(..), ReduceSyms(..), pms_syms, rs_syms )
+  import Ra.Lang ( SymTable, Sym(..), SymApp(..), StackBranch(..), unSB, Stack(..), ReduceSyms(..), PatMatchSyms(..), Write(..) )
   import Ra.Lang.Extra ( ppr_sa )
 
   import Outputable ( Outputable, interppSP, showSDocUnsafe, showPpr )
@@ -57,7 +57,18 @@ module Main where
               }) . unLoc) tl_binds
       -- return $ show $ map (M.mapKeys ppr . M.map (map toConstr) . snd) initial_branch
       -- pure ()
-      return $ uncurry (++) $ (concatMap ((++"\n") . ppr_sa (showPpr dflags)) . rs_syms &&& concatMap ((++"\n") . ppr_sa (showPpr dflags) . snd) . concat . M.elems . rs_writes) $ reduce initial_table $ (expr $ sa_sym $ head $ (!!1) $ M.elems $ initial_table)
+      return $ uncurry (++) $ (
+          concatMap (
+              (++"\n") . ppr_sa (showPpr dflags)
+            )
+          . rs_syms &&& concatMap (
+            (++"\n")
+            . ppr_sa (showPpr dflags)
+            . w_sym)
+          . concat
+          . M.elems
+          . rs_writes
+        ) $ reduce initial_table $ (expr $ sa_sym $ head $ (!!1) $ M.elems $ initial_table)
       
       -- return $ show $ map (show_sym dflags) $ concatMap (flip (reduce_deep $ [(noSrcSpan, SymTable $ unionsWith (++) $ map (bind_to_table ([(noSrcSpan, SymTable M.empty)]) . unLoc) $ bagToList (typecheckedSource t))]) []) ((concat $ shallowest cast (last $ bagToList (typecheckedSource t))) :: [HsExpr GhcTc])
       

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -13,12 +13,13 @@ module Main where
   import Data.Generics ( cast, mkQ, extQ, everything, toConstr, Data(..) )
   import Data.Generics.Extra ( constr_ppr, shallowest, everything_ppr )
   import qualified Data.Map.Strict as M ( empty, elems )
-  import Data.Tuple.Extra ( (&&&), (***) )
+  import Data.Tuple.Extra ( first, (&&&), (***) )
+  import Data.Maybe ( fromMaybe )
   import Control.Monad ( mzero )
   
-  import Ra ( pat_match, reduce )
-  import Ra.GHC ( bind_to_table )
-  import Ra.Lang ( SymTable, Sym(..), SymApp(..), StackBranch(..), unSB, Stack(..), ReduceSyms(..), PatMatchSyms(..), Write(..) )
+  import Ra ( pat_match, reduce, reduce_deep )
+  import Ra.GHC ( bind_to_table, grhs_binds )
+  import Ra.Lang -- ( SymTable, Sym(..), SymApp(..), StackBranch(..), unSB, Stack(..), ReduceSyms(..), PatMatchSyms(..), Write(..) )
   import Ra.Lang.Extra
 
   import Outputable ( Outputable, interppSP, showSDocUnsafe, showPpr )
@@ -27,7 +28,10 @@ module Main where
   ppr = showSDocUnsafe . interppSP . pure
   
   ppr_branch :: StackBranch -> String
-  ppr_branch = foldr ((++) . (++"---\n\n") . foldr ((++) . (++"\n\n") . uncurry (++) . (((++", ") . ppr) *** concatMap (ppr . sa_sym))) "" . toList . snd) "" . unSB
+  ppr_branch = foldr (\case
+      AppFrame sa syms -> flip (foldr ((++) . (++"\n\n") . uncurry (++) . (((++", ") . ppr) *** concatMap (ppr . sa_sym)))) (M.assocs syms) . (++"---\n\n")
+      _ -> id
+    ) "" . unSB
 
   main :: IO ()
   main = do
@@ -46,59 +50,10 @@ module Main where
       p <- parseModule modSum
       t <- typecheckModule p
       
-      -- _ <- mapM (putStrLn . show . constr_ppr) tl_binds
-      -- return $ foldr ((++) . ('\n':) . showPpr dflags) "" tl_binds
-      -- return $ foldr (\x -> (++((constr_ppr x ++ "\n" ++ showPpr dflags x ++ "\n---")))) "" tl_binds
-      -- return $ show $ map (showPpr dflags) ((concat $ shallowest cast (last tl_binds)) :: [HsExpr GhcTc]) -- ) []
+      let st0 = Stack (SB []) (SB [], SB [])
+          initial_pms = grhs_binds st0 (typecheckedSource t)
+          syms0 = pms2rs initial_pms -- (\s -> s { sa_stack = append_frame (AppFrame s (pms_syms initial_pms)) (sa_stack s) }) $ head $ (!!0) $ M.elems $ 
       
-      let tl_binds = bagToList (typecheckedSource t)
-          initial_pms = mconcat $ map (bind_to_table (mempty {
-                st_branch = SB [(noSrcSpan, M.empty)]
-              }) . unLoc) tl_binds
-      -- return $ show $ map (M.mapKeys ppr . M.map (map toConstr) . snd) initial_branch
-      -- pure ()
-      -- return $ uncurry (++) $ (
-      --     concatMap (
-      --         (++"\n") . ppr_sa (showPpr dflags)
-      --       )
-      --     . rs_syms &&& concatMap (
-      --       (++"\n")
-      --       . ppr_sa (showPpr dflags)
-      --       . w_sym)
-      --     . concat
-      --     . M.elems
-      --     . rs_writes
-      --   ) $ reduce initial_table $ (sa_sym $ head $ (!!1) $ M.elems $ initial_table)
-      
-      let rs = reduce (pms_syms initial_pms) $ (sa_sym $ head $ (!!1) $ M.elems $ (pms_syms initial_pms))
-      -- return $ ppr_pms (showPpr dflags) initial_pms
-      return $ ppr_rs (showPpr dflags) $ rs {
-        rs_writes = M.unionWith (++) (pms_writes initial_pms) (rs_writes rs),
-        rs_holds = pms_holds initial_pms <> rs_holds rs
-      }
-      -- return $ concatMap (uncurry ((++) . (++" -> ")) . (showPpr dflags *** concatMap (showPpr dflags . getLoc . (\(HsLam _ m) -> mg_alts m) . unLoc . sa_sym))) $ M.assocs $ pms_syms initial_pms
-      
-      -- return $ show $ map (show_sym dflags) $ concatMap (flip (reduce_deep $ [(noSrcSpan, SymTable $ unionsWith (++) $ map (bind_to_table ([(noSrcSpan, SymTable M.empty)]) . unLoc) $ bagToList (typecheckedSource t))]) []) ((concat $ shallowest cast (last $ bagToList (typecheckedSource t))) :: [HsExpr GhcTc])
-      
-      -- return $ concat $ everything (++) ([] `mkQ` ((\b -> case b of
-      --     FunBind{ fun_id } -> [(show $ varUnique $ unLoc fun_id) ++ " | " ++ (showPpr dflags b) ++ "\n"]
-      --     VarBind{ var_id } -> [(show $ varUnique var_id) ++ " | " ++ (showPpr dflags b) ++ "\n"]
-      --     _ -> []
-      --   ) :: HsBind GhcTc -> [String])) tl_binds
-      
-      -- return $ foldr1 ((++) . ('\n':)) $ map (\x -> (show $ getUnique x) ++ " | " ++ (showPpr dflags x)) $ (everything (++) ([] `mkQ` ((pure . id) :: Id -> [Id])) tl_binds)
-      -- return $
-        -- everything_ppr ((show . toConstr) `extQ` ((uncurry ((++) . (++" | ")) . (showPpr dflags &&& show . getUnique)) :: Id -> String)) tl_binds
-      --   ++ "\n"
-      --   ++ (everything (++) ([] `mkQ` ((\expr -> case expr of { (HsVar (L _ v)) -> (showPpr dflags expr ++ " | " ++ (show $ varUnique v)) ++ "\n"; _ -> "" }))) $ concatMap (reduce_deep initial_branch []) ((concat $ shallowest cast (last tl_binds)) :: [HsExpr GhcTc]))
-        
-      -- return $ show $ (\(L _ (AbsBinds{ abs_ev_binds })) -> map (showPpr dflags) abs_ev_binds) (last tl_binds)
-      
-      -- return $ show $ map (showPpr dflags) tl_binds
+      -- return $ ppr_rs (showPpr dflags) $ reduce syms0
+      return $ ppr_pms (showPpr dflags) initial_pms
       -- return $ constr_ppr $ typecheckedSource t
-      -- return $ constr_ppr $ head $ ((concat $ shallowest cast (last tl_binds)) :: [HsExpr GhcTc])
-      
-      -- let initial_branch = [()]
-      -- initial_table = bind_to_table [(empty, (typecheckedSource t))] -- BOOKMARK do this tomorrow
-      -- t & typecheckedSource & mapBag (fun_matches & )
-      

--- a/src/Ra.hs
+++ b/src/Ra.hs
@@ -50,38 +50,36 @@ import Ra.Refs ( write_funs, read_funs )
 -- Ref holds the expression that spits out the pipe that holds the value[s] that we must trace in a separate traversal over ref types. Note the Located because we use SrcSpan to find specific write instances
 
 -- app :: Sym -> [Sym] -> Sym
--- app = foldl (curry $ Sym False mempty . noLoc . uncurry (HsApp undefined) . both (expr . coerce)) -- one downside is the noLoc on the app, but all the actual exprs are located
+-- app = foldl (curry $ Sym False mempty . noLoc . uncurry (HsApp undefined) . both (coerce)) -- one downside is the noLoc on the app, but all the actual exprs are located
 
 pat_multi_match ::
-  Stack -- full symbol table
-  -> [Pat GhcTc]
+  [Pat GhcTc]
   -> [[SymApp]]
   -> Maybe PatMatchSyms
-pat_multi_match stack pats args =
-  let matches = map (uncurry ((mconcat.) . map . pat_match stack)) (zip pats args)
+pat_multi_match pats args =
+  let matches = map (uncurry ((mconcat.) . map . pat_match)) (zip pats args)
   in foldl1 (<>) matches
 
 -- invoke as: `unions . concatMap (map ((unions . concatMap . pat_match table) . unLoc) . zip args . m_pats) mg_alts` on `MatchGroup`'s `mg_alts`
 pat_match ::
-  Stack
-  -> Pat GhcTc
+  Pat GhcTc
   -> SymApp
   -> Maybe PatMatchSyms -- the new bindings in _this stack frame only_, even if new ones are resolved above and below
 -- all new matches from the pat match; M.empty denotes the match failed (we'll bind wildcards under `_` which will be ignored later since it's an illegal variable and function name)
 -- Valid HsExpr: HsApp, OpApp, NegApp, ExplicitTuple, ExplicitList, (SectionL, SectionR) (for data types that are named by operators, e.g. `:`; I might not support this in v1 because it's so thin)
 -- Valid Pat:
-pat_match stack pat sa =
-  let nf_syms = reduce_deep stack sa
+pat_match pat sa =
+  let nf_syms = reduce_deep sa
   in case pat of
     ---------------------------------
     -- *** UNWRAPPING PATTERNS *** --
     ---------------------------------
     WildPat ty -> Just $ mempty { pms_writes = rs_writes nf_syms } -- TODO check if this is the right [write, haha] behavior
     -- wrapper
-    LazyPat _ (L _ pat) -> pat_match stack pat sa
-    ParPat _ (L _ pat) -> pat_match stack pat sa
-    BangPat _ (L _ pat) -> pat_match stack pat sa
-    -- SigPatOut (L _ pat) _ -> pat_match stack pat sa
+    LazyPat _ (L _ pat) -> pat_match pat sa
+    ParPat _ (L _ pat) -> pat_match pat sa
+    BangPat _ (L _ pat) -> pat_match pat sa
+    -- SigPatOut (L _ pat) _ -> pat_match pat sa
     -- base
     VarPat _ (L _ v) -> Just $ mempty {
         pms_syms = singleton v (rs_syms nf_syms),
@@ -90,9 +88,9 @@ pat_match stack pat sa =
     LitPat _ _ -> Just mempty -- no new name bindings
     NPat _ _ _ _ -> Just mempty
     -- container
-    ListPat _ pats -> mconcat $ map (\(L _ pat') -> pat_match stack pat' sa) pats -- encodes the logic that all elements of a list might be part of the pattern regardless of order
+    ListPat _ pats -> mconcat $ map (\(L _ pat') -> pat_match pat' sa) pats -- encodes the logic that all elements of a list might be part of the pattern regardless of order
     AsPat _ (L _ bound) (L _ pat') -> -- error "At patterns (@) aren't yet supported."
-      let matches = pat_match stack pat' sa
+      let matches = pat_match pat' sa
       in (mappend (mempty { pms_syms = singleton bound [sa] })) <$> matches -- note: `at` patterns can't be formally supported, because they might contain sub-patterns that need to hold. They also violate the invariant that "held" pattern targets have a read operation on their surface. However, since this only makes the test _less sensitive_, we'll try as hard as we can and just miss some things later.
         -- TODO test this: the outer binding and inner pattern are related: the inner pattern must succeed for the outer one to as well.
         
@@ -104,22 +102,21 @@ pat_match stack pat sa =
       pms_holds = pms_holds pms <> rs_holds nf_syms
     }) next_pms where
       next_pms = mconcat $ map pat_match' (rs_syms nf_syms)
-      pat_match' sa | HsVar _ v  <- unLoc $ expr $ sa_sym sa
+      pat_match' sa' | HsVar _ v  <- unLoc $ sa_sym sa'
                     , "readMVar" == (varString $ unLoc v)
                     = Just $ mempty { -- TODO sketchy making this a "hit" when it's not yet matched
                         pms_holds = pure $ Hold {
                             h_pat = pat,
-                            h_sym = sa,
-                            h_stack = stack
+                            h_sym = sa'
                           }
                       }
-      pat_match' sa = case pat of
+      pat_match' sa' = case pat of
         TuplePat _ pats _ ->
-          let matcher (SA _ _ (x:_)) = error "Argument on explicit tuple. Perhaps a tuple section, which isn't supported yet."
-              matcher (SA _ sym' _) = case unLoc $ expr sym' of
+          let matcher (SA _ _ _ (x:_)) = error "Argument on explicit tuple. Perhaps a tuple section, which isn't supported yet."
+              matcher (SA _ _ sym' _) = case unLoc sym' of
                 ExplicitTuple _ args'' _ ->
-                  pat_multi_match stack (map unLoc pats) $ map ((\case
-                      Present _ expr' -> [SA [] ((sa_sym sa) { expr = expr' }) []] -- NB encodes the assumption that we should preserve the original location of creation for this object, rather than this unravelling point because the datatype decompositions are trivial and can't define an object's identity
+                  pat_multi_match (map unLoc pats) $ map ((\case
+                      Present _ expr' -> [SA [] (sa_stack sa') expr' []] -- NB encodes the assumption that we should preserve the original location of creation for this object, rather than this unravelling point because the datatype decompositions are trivial and can't define an object's identity
                       Missing _ -> error "Tuple sections aren't supported yet."
                     ) . unLoc) args''
                 _ -> Nothing
@@ -128,10 +125,10 @@ pat_match stack pat sa =
           
         ConPatOut{ pat_con = L _ (RealDataCon pat_con'), pat_args = d_pat_args } -> case d_pat_args of
           PrefixCon pats ->
-            let matcher (SA consumers' sym' args') | (L _ (HsConLikeOut _ (RealDataCon con)), args'') <- deapp (expr sym') -- sym' is in NF thanks to pat_multi_match; this assumes it
+            let matcher (SA consumers' stack' sym' args') | (L _ (HsConLikeOut _ (RealDataCon con)), args'') <- deapp sym' -- sym' is in NF thanks to pat_multi_match; this assumes it
                                                    , dataConName con == dataConName pat_con' -- TEMP disable name matching on constructor patterns, to allow symbols to always be bound to everything
-                                                    = let flat_args = ((map (\arg'' -> [SA [] (sym' { expr = arg'' }) []]) args'') ++ args') -- [[SymApp]]
-                                                      in pat_multi_match stack (map unLoc pats) flat_args
+                                                    = let flat_args = ((map (\arg'' -> [SA [] (sa_stack sa') arg'' []]) args'') ++ args') -- TODO check if this stack is correct
+                                                      in pat_multi_match (map unLoc pats) flat_args
                                                    | otherwise = Nothing
                 next_pms' = mconcat $ map matcher (rs_syms nf_syms)
             in (append_pms_writes (rs_writes nf_syms)) <$> next_pms'
@@ -140,14 +137,14 @@ pat_match stack pat sa =
           
         _ -> error $ constr_ppr pat
 
-reduce :: SymTable -> LHsExpr GhcTc -> ReduceSyms -- SymTable for ambient declarations
+reduce :: SymTable -> Sym -> ReduceSyms -- SymTable for ambient declarations
 reduce table root =
   let stack0 = mempty { st_branch = SB [(noSrcSpan, table)] }
-      syms0 = reduce_deep stack0 (SA [] (Sym [] root) [])
+      syms0 = reduce_deep (SA [] stack0 root [])
       
       expand_reads :: Writes -> SymApp -> [SymApp]
-      expand_reads ws sa | HsVar _ v <- unLoc $ expr $ sa_sym sa
-                         = concat $ concatMap (maybeToList . fmap (map w_sym) . (ws!?) . stack_loc . sa_sym) $ -- a bunch of null handling
+      expand_reads ws sa | HsVar _ v <- unLoc $ sa_sym sa
+                         = concat $ concatMap (maybeToList . fmap (map w_sym) . (ws!?) . make_stack_key . sa_stack) $ -- a bunch of null handling
                           case varString $ unLoc v of -- return all pipes
                             "newMVar" -> [sa]
                             "readMVar" -> (concatMap (expand_reads ws) (head $ sa_args sa)) -- list of pipes from the first arg
@@ -160,12 +157,12 @@ reduce table root =
       -- -- for every pipe, make a set of terminal symbols written from different threads, updating the threads to be enemies -- this is so that we can pat-match knowing these are as terminal as we can get them; then expect pattern matching to screen out the duds (mostly unresolved functions, especially writes) -- IMPORTANT POINT: DON'T COMMIT THE OUTPUT TO MEMORY: we're going to re-expand every pipe every time
       -- expand_writes ss = M.map (concatMap ((expand_reads (rs_writes ss)) . w_sym) (rs_writes ss))
       
-      expand_hold :: Writes -> Hold -> PatMatchSyms
-      expand_hold ws h = mconcat $ catMaybes $ map (pat_match (h_stack h) (h_pat h)) (expand_reads ws (h_sym h))
+      expand_hold :: Writes -> Hold -> [PatMatchSyms]
+      expand_hold ws h = catMaybes $ map (pat_match (h_pat h)) (expand_reads ws (h_sym h))
       
       left_outer_writes :: Writes -> Writes -> Writes
       left_outer_writes l r =
-        let (l_lookups, r_lookups) = both (M.map (map (stack_loc . sa_sym . w_sym &&& id))) (l, r)
+        let (l_lookups, r_lookups) = both (M.map (map (make_stack_key . sa_stack . w_sym &&& id))) (l, r)
         in foldrWithKey (\k v m ->
             let r_lookup = r_lookups ! k
                 l_lookup = l_lookups ! k
@@ -188,11 +185,12 @@ reduce table root =
       iterant :: ReduceStateMachine -> (Bool, ReduceStateMachine)
       iterant rs =
         let next_writes = uncurry left_outer_writes $ both rs_writes (rsm_syms rs)
-            (next_iterants, next_stacks) = unzip $ map (\h ->
-                (id &&& flip update_head_table (h_stack h) . pms_syms) $ expand_hold (next_writes) h -- eh, not great
-              ) (rs_holds $ fst $ rsm_syms rs) -- actually, this is still a loop over a populated list; we can't avoid computation, since the stacks coming out of here will be non-empty
+            next_hold_expands = map (id &&& expand_hold next_writes) (rs_holds $ fst $ rsm_syms rs)
+            next_stacks = map (\(h, pmss) -> update_head_table (unionsWith (++) $ map pms_syms pmss) (sa_stack $ h_sym h)) next_hold_expands  -- actually, this is still a loop over a populated list; we can't avoid computation, since the stacks coming out of here will be non-empty
             make_syms w st | is_parent (st_branch st) (st_branch $ w_stack w)
-                           = reduce_deep st (w_sym w)
+                           = reduce_deep (w_sym w) {
+                             sa_stack = st -- TODO URGENT check if this stack is the right one
+                           }
                            | otherwise = mempty
             -- next_syms = mconcat $ M.map (concatMap (rs_writes)) 
             
@@ -201,26 +199,29 @@ reduce table root =
                 st <- next_stacks,
                 w <- concat $ elems $ rs_writes $ fst $ rsm_syms rs
               ]
-        in (M.null next_writes, RSM {
-          rsm_stacks = next_stacks,
-          rsm_syms = (next_syms, fst $ rsm_syms rs)
-        })
-        
-  in snd $ rsm_syms $ snd $ until fst (iterant . snd) (False, mempty {
-      rsm_syms = (syms0, mempty)
-    })
--- reduce = curry $ uncurry (flip reduce_deep) . (flip SA [] . Sym False [] *** SB . pure . (noLoc,)) -- yeah, sometimes pointfree ain't worth it
+        in (
+            M.null next_writes && (null $ concatMap snd next_hold_expands),
+            RSM {
+              rsm_stacks = next_stacks,
+              rsm_syms = (next_syms, uncurry (<>) $ rsm_syms rs)
+            }
+          )
+      res = until (fst . snd) (((+1) *** iterant . snd)) (0, (False, mempty {
+        rsm_syms = (syms0, mempty)
+      }))
+  in snd $ rsm_syms $ snd $ snd res
+-- reduce = curry $ uncurry (flip reduce_deep) . (flip (SA []) [] *** SB . pure . (noLoc,)) -- yeah, sometimes pointfree ain't worth it
 
-reduce_deep :: Stack -> SymApp -> ReduceSyms
-reduce_deep _ sa | let args = sa_args sa
-                       sym = sa_sym sa
-                 , length args > 0 && is_zeroth_kind sym = error $ "Application on " ++ (show $ toConstr $ expr sym)
-reduce_deep stack sa@(SA consumers sym args) =
+reduce_deep :: SymApp -> ReduceSyms
+reduce_deep sa | let args = sa_args sa
+                     sym = sa_sym sa
+               , length args > 0 && is_zeroth_kind sym = error $ "Application on " ++ (show $ toConstr sym)
+reduce_deep sa@(SA consumers stack sym args) =
   -------------------
   -- SYM BASE CASE --
   -------------------
   let terminal =
-        let args' = map (map (reduce_deep stack)) args -- [[ ([SymApp], Writes) ]], to become ([[SymApp]], Writes)
+        let args' = map (map reduce_deep) args -- [[ ([SymApp], Writes) ]], to become ([[SymApp]], Writes)
             extract :: Monoid a => (ReduceSyms -> a) -> [a]
             extract f = map (mconcat . map f) args'
         in mempty {
@@ -229,20 +230,19 @@ reduce_deep stack sa@(SA consumers sym args) =
         } -- NOTE the detachment of sym from write. Hopefully that isn't eventually an issue.
       
       unravel1 :: LHsExpr GhcTc -> [[LHsExpr GhcTc]] -> ReduceSyms -- peeling back wrappings; consider refactor to evaluate most convenient type to put here
-      unravel1 target new_args = reduce_deep stack $ SA {
+      unravel1 target new_args = reduce_deep SA {
+          sa_stack = stack,
           sa_consumers = [],
-          sa_sym = sym {
-              expr = target
-            },
-          sa_args = (map (map (\arg -> SA [] (Sym (make_stack_key stack) arg) [])) new_args ++ args) -- NB `consumed` law: `consumers` property at least distributes over App; if the leftmost var is of type `Consumer`, then it might make some args `consumed` as well.
+          sa_sym = target,
+          sa_args = map (map (\arg -> SA [] stack arg [])) new_args ++ args -- NB `consumed` law: `consumers` property at least distributes over App; if the leftmost var is of type `Consumer`, then it might make some args `consumed` as well.
         }
       
-      fail = error $ "FAIL" ++ (constr_ppr $ expr $ sym)
-  in case unLoc $ expr sym of
-    HsLamCase _ mg -> unravel1 (HsLam undefined mg <$ expr sym) []
+      fail = error $ "FAIL" ++ (constr_ppr $ sym)
+  in case unLoc sym of
+    HsLamCase _ mg -> unravel1 (HsLam undefined mg <$ sym) []
     
     HsLam _ mg | let loc = getLoc $ mg_alts mg -- <- NB this is why the locations of MatchGroups don't matter
-             , not $ is_visited stack loc -> -- beware about `noLoc`s showing up here: maybe instead break out the pattern matching code
+               , not $ is_visited stack loc -> -- beware about `noLoc`s showing up here: maybe instead break out the pattern matching code
       if matchGroupArity mg > length args
         then terminal
         else
@@ -250,26 +250,28 @@ reduce_deep stack sa@(SA consumers sym args) =
                 (unLoc $ mg_alts mg) & mconcat . mconcat . map ( -- over function body alternatives
                   map ( -- over arguments
                     mconcat . catMaybes . map ( -- over possible expressions
-                      uncurry (flip (pat_match stack)) -- share the same stack
+                      uncurry (flip pat_match) -- share the same stack
                     ) . (uncurry zip) . (id *** repeat)
                   ) . zip (sa_args sa) . map unLoc . m_pats . unLoc -- `args` FINALLY USED HERE
                 )
               
-              PatMatchSyms {
+              bind_pms@(PatMatchSyms {
                   pms_syms = next_explicit_binds,
                   pms_holds = holds,
                   pms_writes = bind_writes
-                } = grhs_binds stack mg
+                }) = grhs_binds (append_frame (loc, mempty) stack) mg -- localize binds correctly via pushing next stack location
               next_exprs = grhs_exprs $ map (grhssGRHSs . m_grhss . unLoc) $ unLoc $ mg_alts mg
               next_frame = (loc, union_sym_tables [pms_syms pat_matches, next_explicit_binds])
-              next_stack = stack {
-                  st_branch = SB (next_frame : (coerce $ st_branch stack))
-                }
+              next_stack = append_frame next_frame stack
               next_args = drop (matchGroupArity mg) args
-          in mempty { rs_writes = bind_writes <> pms_writes pat_matches }
+          in mempty {
+            rs_writes = pms_writes bind_pms <> pms_writes pat_matches,
+            rs_holds = pms_holds bind_pms <> pms_holds pat_matches
+          }
             <> (mconcat $ map (\next_expr ->
-                reduce_deep next_stack $ sa {
-                  sa_sym = sym { expr = next_expr },
+                reduce_deep sa {
+                  sa_stack = next_stack,
+                  sa_sym = next_expr,
                   sa_args = next_args
                 }
               ) next_exprs) -- TODO check if the sym record update + args are correct for this stage
@@ -289,7 +291,7 @@ reduce_deep stack sa@(SA consumers sym args) =
               -- DEBUG SYMBOL
               mempty
            | Just left_syms <- stack_var_lookup True v stack -> -- this absolutely sucks, we have to use the "soft" search because instance name Uniques are totally unusable. Can't even use `Name`, unless I convert to string every time... which I might need to do in the future for performance reasons if I can't come up with a solution for this. 
-            mconcat $ map (\sa' -> reduce_deep stack $ sa' { sa_args = sa_args sa' ++ args' }) left_syms
+            mconcat $ map (\sa' -> reduce_deep sa' { sa_args = sa_args sa' ++ args' }) left_syms
       -- in foldr ((++) . flip (reduce_deep stack) args) [] nf_left
            | otherwise -> case varString v of
             ------------------------------------
@@ -303,17 +305,17 @@ reduce_deep stack sa@(SA consumers sym args) =
             --   else terminal
             
             -- MAGIC MONADS (fallthrough)
-            "return" | vs:args'' <- args' -> mconcat $ map (\sa' -> reduce_deep stack $ sa' { sa_args = args'' }) vs
+            "return" | vs:args'' <- args' -> mconcat $ map (\sa' -> reduce_deep sa' { sa_args = args'' }) vs
             -- NB about `[]` on the rightmost side of the pattern match on `args'`: it's never typesafe to apply to a monad (except `Arrow`), so if we see arguments, we have to freak out and not move forward with that.
               
             ">>" | i:o:[] <- args'
-                 , let i' = map (reduce_deep stack) i
-                       o' = map (reduce_deep stack) o -> -- magical monad `*>` == `>>`: take right-hand syms, merge writes
+                 , let i' = map reduce_deep i
+                       o' = map reduce_deep o -> -- magical monad `*>` == `>>`: take right-hand syms, merge writes
                   mconcat [i'' { rs_syms = mempty } <> o'' | i'' <- i', o'' <- o'] -- combinatorial EXPLOSION! BOOM PEW PEW
             ">>=" | i:o:[] <- args' -> -- magical monad `>>=`: shove the return value from the last stage into the next, merge writes
                   -- grabbing the writes is as easy as just adding `i` to the arguments; the argument resolution in `terminal` will take care of it
                   -- under the assumption that it's valid to assume IO is a pure wrapper, this actually just reduces to plain application of a lambda
-                    mconcat $ map (\fun -> reduce_deep stack fun {
+                    mconcat $ map (\fun -> reduce_deep fun {
                           sa_args = sa_args fun ++ [i]
                         }
                       ) o
@@ -323,7 +325,8 @@ reduce_deep stack sa@(SA consumers sym args) =
                         st_threads = (length $ unSB $ st_branch stack) : st_threads stack,
                         st_branch = SB $ ((loc, M.empty):) $ coerce $ st_branch stack
                       }
-                    result = mconcat $ map (\sa' -> reduce_deep next_stack $ sa' {
+                    result = mconcat $ map (\sa' -> reduce_deep sa' {
+                        sa_stack = next_stack,
                         sa_args = (sa_args sa' ++ rest)
                       }) to_fork
                 in result {
@@ -335,7 +338,7 @@ reduce_deep stack sa@(SA consumers sym args) =
                 let (pipes:vals:_) = args'
                 in terminal {
                     rs_writes = unionWith (++) (rs_writes terminal) (unionsWith (++) [
-                        singleton (stack_loc $ sa_sym pipe) [
+                        singleton (make_stack_key $ sa_stack pipe) [
                             Write {
                               w_stack = stack,
                               w_sym = val
@@ -350,7 +353,7 @@ reduce_deep stack sa@(SA consumers sym args) =
             _ -> terminal
       
     HsApp _ _ _ -> -- this should only come up from the GHC AST, not from our own reduce-unwrap-wrap
-      let (fun, next_args) = deapp $ expr sym
+      let (fun, next_args) = deapp sym
           passthrough = unravel1 fun (map pure next_args)
       in case unLoc fun of
         HsConLikeOut _ _ -> terminal
@@ -359,7 +362,7 @@ reduce_deep stack sa@(SA consumers sym args) =
     OpApp _ l_l l_op l_r -> unravel1 l_op [[l_l], [l_r]]
     
     -- Wrappings
-    HsWrap _ _ v -> unravel1 (const v <$> expr sym) [] -- why is HsWrap wrapping a bare HsExpr?! No loc? Inferred from surroundings I guess (like this)
+    HsWrap _ _ v -> unravel1 (const v <$> sym) [] -- why is HsWrap wrapping a bare HsExpr?! No loc? Inferred from surroundings I guess (like this)
     NegApp _ v _ -> unravel1 v []
     HsPar _ v -> unravel1 v []
     SectionL _ v m_op -> unravel1 m_op [[v]]
@@ -367,12 +370,11 @@ reduce_deep stack sa@(SA consumers sym args) =
       let L _ (HsVar _ op) = unHsWrap m_op
       in case stack_var_lookup True (unLoc op) stack of
         Just branch_exprs -> mconcat $ map (\sa' ->
-            reduce_deep stack $ SA {
+            reduce_deep $ SA {
               sa_consumers = [],
-              sa_sym = (sa_sym sa') {
-                  expr = (\(HsLam x mg) -> HsLam x (mg_flip mg)) <$> (expr $ sa_sym sa')
-                },
-              sa_args = [[sa { sa_sym = sym { expr = v } }]] ++ (sa_args sa') ++ args -- TODO also do the operator constructor case -- TODO check that `sym` record update is the right thing to do here
+              sa_stack = sa_stack sa,
+              sa_sym = (\(HsLam x mg) -> HsLam x (mg_flip mg)) <$> (sa_sym sa'),
+              sa_args = [[sa { sa_sym = v }]] ++ (sa_args sa') ++ args -- TODO also do the operator constructor case -- TODO check that `sym` record update is the right thing to do here
             }
           ) branch_exprs
         Nothing -> terminal
@@ -387,7 +389,12 @@ reduce_deep stack sa@(SA consumers sym args) =
             } = grhs_binds stack rhss
           next_exprs = grhs_exprs rhss
           next_frame = (noSrcSpan, next_explicit_binds)
-      in mempty { rs_writes = bind_writes } <> (mconcat $ map (\next_expr -> reduce_deep (stack { st_branch = mapSB (next_frame:) (st_branch stack) }) (sa { sa_sym = sym { expr = next_expr } })) next_exprs) -- TODO check that record update with sym (and its location) is the right move here
+      in mempty { rs_writes = bind_writes }
+        <> (mconcat $ map (\next_expr ->
+            reduce_deep sa {
+              sa_sym = next_expr,
+              sa_stack = (stack { st_branch = mapSB (next_frame:) (st_branch stack) })
+            }) next_exprs) -- TODO check that record update with sym (and its location) is the right move here
       
     HsLet _ _ expr -> unravel1 expr [] -- assume local bindings already caught by surrounding function body (HsLam case)
     HsDo _ _ (L _ stmts) -> foldl (\syms (L _ stmt) ->
@@ -411,7 +418,7 @@ reduce_deep stack sa@(SA consumers sym args) =
     ExplicitSum _ _ _ _ -> terminal
     ExplicitList _ _ _ -> terminal
     -- ExplicitPArr _ _ -> terminal
-    _ -> error ("Incomplete coverage of HsExpr rules: encountered " ++ (show $ toConstr $ expr sym))
+    _ -> error ("Incomplete coverage of HsExpr rules: encountered " ++ (show $ toConstr sym))
 
 -- type Violation = (StackKey, StackKey)
 -- linkIO :: Writes -> [Violation] -- consumer-pipe violated pairs
@@ -434,7 +441,7 @@ reduce_deep stack sa@(SA consumers sym args) =
 --   lookup_deep visited p | not $ S.member p visited =
 --     let dig_write :: SymApp -> [Write]
 --         dig_write sa = -- resolve new writes from this write (if this write is composed of reads)
---           if | HsVar _ v <- unLoc $ expr $ sa_sym sa
+--           if | HsVar _ v <- unLoc $ sa_sym sa
 --              , (varString $ unLoc v) == "readMVar"
 --              , (length $ sa_args sa) >= 1
 --                -> concatMap dig_metapipe (head $ sa_args sa) -- head of args should be the pipe
@@ -442,7 +449,7 @@ reduce_deep stack sa@(SA consumers sym args) =
         
 --         dig_metapipe :: SymApp -> [Pipe]
 --         dig_metapipe sa =
---           let syms = case unLoc $ expr $ sa_sym sa of
+--           let syms = case unLoc $ sa_sym sa of
 --                       HsVar _ v' -> case (varString $ unLoc v') of
 --                         "newMVar" -> ws ! (stack_loc $ sa_sym sa) -- TODO verify stack_loc always coincides with the logged location of the pipe
 --                         "readMVar" -> map (sa_sym . snd) $ lookup_deep (S.insert p visited) sa -- resolve meta-pipe; don't worry about discarding the thread info from the write, as this pipe as a _value_ will be handled in another iteration through the Writes table

--- a/src/Ra/Extra.hs
+++ b/src/Ra/Extra.hs
@@ -1,7 +1,11 @@
 module Ra.Extra (
   update_head,
-  zipAll
+  zipAll,
+  list_alt,
+  map_alt
 ) where
+  import qualified Data.Map.Strict as M
+  
   update_head :: (a -> a) -> [a] -> [a]
   update_head f (x:xs) = (f x):xs
   
@@ -15,3 +19,11 @@ module Ra.Extra (
   lumpAll (x:xs) (y:ys) = (x ++ y) : lumpAll xs ys
   lumpAll [] (y:ys) = y : lumpAll [] ys
   lumpAll (x:xs) [] = x : lumpAll xs []
+  
+  list_alt :: [a] -> [a] -> [a]
+  list_alt a@(_:_) _ = a
+  list_alt _ b = b
+  
+  map_alt :: M.Map k v -> M.Map k v -> M.Map k v
+  map_alt a b | M.null a = b
+              | otherwise = a

--- a/src/Ra/GHC.hs
+++ b/src/Ra/GHC.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE Rank2Types, ScopedTypeVariables, LambdaCase, TupleSections, NamedFieldPuns #-}
 module Ra.GHC (
+  Binds,
   deapp,
   unHsWrap,
   grhs_exprs,
@@ -23,7 +24,7 @@ import Bag
 import Data.Generics ( Data(..), everythingBut, GenericQ, cast, mkQ, extQ, gmapQ )
 import Data.Generics.Extra ( shallowest, constr_ppr )
 import Data.Bool ( bool )
-import Data.Tuple.Extra ( second, (&&&), (***) )
+import Data.Tuple.Extra ( first, second, (&&&), (***) )
 import Data.Maybe ( catMaybes, fromMaybe )
 import Data.Monoid ( mempty, mconcat )
 import Data.Semigroup ( (<>) )
@@ -31,8 +32,8 @@ import Data.Map.Strict ( unionWith, unionsWith, insert, singleton, empty, fromLi
 
 import Control.Applicative ( liftA2 )
 
-import Ra ( pat_match )
-import Ra.Lang ( Stack(..), SymApp(..), Sym(..), SymTable(..), PatMatchSyms(..), StackBranch(..), unSB, mapSB, union_sym_tables, make_stack_key )
+import Ra ( pat_match, reduce_deep )
+import Ra.Lang -- ( Stack(..), SymApp(..), Sym(..), SymTable(..), PatMatchSyms(..), ReduceSyms(..), StackBranch(..), unSB, mapSB, union_sym_tables, make_stack_key )
 import Ra.Extra
 
 unHsWrap :: LHsExpr GhcTc -> LHsExpr GhcTc
@@ -47,13 +48,12 @@ deapp expr =
     HsApp _ l r -> (id *** (++[r])) (deapp l)
     _ -> (unwrapped, [])
 
-bind_to_table :: Stack -> HsBind GhcTc -> PatMatchSyms -- TODO PatMatchSyms without `Maybe` is an aggressive assertion, losing information. Reconsider.
-bind_to_table stack b = case b of
+bind_to_table :: HsBind GhcTc -> Binds
+bind_to_table b = case b of
   AbsBinds { abs_exports, abs_binds } ->
-    let subbinds = mconcat $ bagToList $ mapBag (bind_to_table stack . unLoc) abs_binds -- consider making union_sym_table just Foldable t => ...
-    in subbinds <> mempty {
-        pms_syms = fromList $ catMaybes $ map (\expr -> (abe_poly expr,) <$> (pms_syms subbinds !? abe_mono expr)) abs_exports
-      }
+    let subbinds = mconcat $ bagToList $ mapBag (bind_to_table . unLoc) abs_binds -- consider making union_sym_table just Foldable t => ...
+    in subbinds <> map (VarPat NoExt . noLoc . abe_poly &&& pure . noLoc . HsVar NoExt . noLoc . abe_mono) abs_exports
+    
   -- AbsBindsSig { abs_sig_export, abs_sig_bind = L _ abs_sig_bind } -> 
   --   let subbinds = bind_to_table stack abs_sig_bind
   --   in subbinds {
@@ -63,25 +63,10 @@ bind_to_table stack b = case b of
   -------------------
   -- SYM BASE CASE --
   -------------------
-  FunBind { fun_id = L _ fun_id, fun_matches } -> mempty {
-      pms_syms = singleton fun_id [ SA {
-          sa_stack = stack,
-          sa_consumers = mempty,
-          sa_sym = noLoc $ HsLam NoExt fun_matches,
-          sa_args = []
-        } ]
-    }
+  FunBind { fun_id = fun_id, fun_matches } -> [( VarPat NoExt fun_id, [noLoc $ HsLam NoExt fun_matches] )]
+  
   PatBind { pat_lhs = L _ pat_lhs, pat_rhs } ->
-    let pms@(PatMatchSyms {
-          pms_syms = next_explicit_binds,
-          pms_writes = bind_writes
-        }) = grhs_binds stack pat_rhs
-        stack' = stack {
-            st_branch = mapSB (update_head (second (union_sym_tables . (:[next_explicit_binds])))) (st_branch stack)
-          }
-        next_exprs = grhs_exprs pat_rhs
-        next_pms = mconcat $ catMaybes $ map (pat_match pat_lhs . flip (SA [] stack') []) next_exprs -- TODO confirm that making a fresh stack key here is the right thing to do
-    in pms { pms_syms = mempty } <> next_pms
+    grhs_binds' pat_rhs <> [(pat_lhs, grhs_exprs pat_rhs)]
   VarBind{} -> mempty
   _ -> error $ constr_ppr b
 
@@ -89,15 +74,69 @@ bind_to_table stack b = case b of
 -- uncurried: Data c => ((forall d. Data d => d -> e), c) -> [e]
 grhs_exprs :: GenericQ [LHsExpr GhcTc]
 grhs_exprs x = map (\(L _ (GRHS _ _ body) :: LGRHS GhcTc (LHsExpr GhcTc)) -> body) (concat $ shallowest cast x)
-grhs_binds :: Stack -> GenericQ PatMatchSyms -- TODO consider passing more info via `GenericQ (Maybe PatMatchSyms)`, and removing the fromMaybe
-grhs_binds stack = fromMaybe mempty . everythingBut (<>) (
-    (Nothing, False)
-    `mkQ` ((,True) . Just . bind_to_table stack)
+
+type Binds = [(Pat GhcTc, [Sym])]
+grhs_binds :: Stack -> GenericQ PatMatchSyms
+grhs_binds st z =
+  let binds = grhs_binds' z
+      sub :: SymTable -> SymApp -> [SymApp]
+      sub t sa =
+        let m_next_args = map (map (sub t)) (sa_args sa)
+            args_changed = any (any (not . null)) m_next_args
+            next_args = map (concatMap (uncurry list_alt . second pure) . uncurry zip) (zip m_next_args (sa_args sa)) -- encode law that arguments can fail to reduce and just fall back to the original form
+            m_next_syms :: Maybe (Maybe [SymApp])
+            -- the only case where the iteration moves forward is when the matching finds a symbol that isn't just references to other symbols after reduction. `sub` could communicate this by just returning new symbols. Still ambiguous on the meaning if we succeed on some bare arguments. But by pattern matching, this could yield new things if the only path to that new binding was through that route, so arguments are preserved if they fail, as opposed to failing the whole block; only if all arguments fail and the symbol resolution fails, basically if _anything_ makes any progress, then we're good
+            m_next_syms = case unLoc $ sa_sym sa of
+              HsVar _ (L _ v) -> if not $ v `elem` (var_ref_tail $ sa_stack sa)
+                then Just $
+                  (
+                      uncurry list_alt
+                      . (concatMap (sub t) &&& id)
+                      . map (\sa' ->
+                          sa' {
+                            sa_stack = append_frame (VarRefFrame v) (sa_stack sa'),
+                            sa_args = (sa_args sa') <> next_args
+                          }
+                        )
+                    )
+                  <$> (t !? v)
+                else Nothing
+              _ -> Just Nothing
+        in fromMaybe [] (fromMaybe (
+            if args_changed
+              then [sa { sa_args = next_args }]
+              else [] -- encode the law that if all arguments have failed and the sym has also failed, this whole match fails
+          ) <$> m_next_syms) -- encode the law that if this is a var reduction cycle, then the result is empty
+      
+      -- BOOKMARK need reduce_deep here, maybe strip away from pat_match for performance later
+      
+      iterant :: [(Pat GhcTc, [SymApp])] -> PatMatchSyms -> (Bool, ([(Pat GhcTc, [SymApp])], PatMatchSyms))
+      iterant binds' pms =
+        let next_pms = fromMaybe mempty $ mconcat $ map (mconcat . uncurry map . first pat_match) binds'
+            syms = map snd binds'
+            m_next_syms = map (map (sub (pms_syms next_pms))) syms
+            changed = any (any (not . null)) m_next_syms
+            next_syms = map (uncurry $ second . ((concatMap (uncurry list_alt . second pure)).) . zip) (zip m_next_syms binds')
+        in (not changed, (next_syms, (pms <> next_pms) {
+          pms_syms = pms_syms next_pms `map_alt` pms_syms pms
+        })) -- look for if `<>` is the right thing to do on this pms chain
+      binds0 = map (second (mconcat . map (reduce_deep . (flip (SA [] st) [])))) binds
+      syms0 = mconcat $ map snd binds0
+      symsn = snd $ snd $ until fst (uncurry iterant . snd) (False, (map (second rs_syms) binds0, mempty))
+  in symsn { -- BOOKMARK this initial condition is really ugly
+      pms_holds = pms_holds symsn <> rs_holds syms0,
+      pms_writes = pms_writes symsn <> rs_writes syms0
+    }
+
+grhs_binds' :: GenericQ Binds -- TODO consider passing more info via `GenericQ (Maybe PatMatchSyms)`, and removing the fromMaybe
+grhs_binds' = everythingBut (<>) (
+    (mempty, False)
+    `mkQ` ((,True) . bind_to_table)
     `extQ` ((,False) . ((\case
-        BindStmt _ (L _ pat) expr _ _ -> pat_match pat (SA [] stack expr []) -- TODO check if a fresh stack key here is the right thing to do
-        _ -> Nothing
-        ) . unLoc :: LStmt GhcTc (LHsExpr GhcTc) -> Maybe PatMatchSyms)) -- TODO dangerous: should we really keep looking deeper after finding a BindStmt?
-    `extQ` ((Nothing,) . ((\case 
+        BindStmt _ (L _ pat) expr _ _ -> [(pat, [expr])] -- TODO check if a fresh stack key here is the right thing to do
+        _ -> mempty
+      ) . unLoc :: LStmt GhcTc (LHsExpr GhcTc) -> Binds)) -- TODO dangerous: should we really keep looking deeper after finding a BindStmt?
+    `extQ` ((mempty,) . ((\case 
       HsApp _ _ _ -> True
       HsLam _ _ -> True
       _ -> False 
@@ -113,7 +152,7 @@ mg_rearg f mg = mg {
     }
 }
 
-mg_drop x = mg_rearg $ drop x -- i don't see why i couldn't do `mg_rearg . drop` but the typechecker complained because the type became rigid
+mg_drop x = mg_rearg $ drop x
 
 mg_flip = mg_rearg (\(a:b:ns) -> b:a:ns)
 

--- a/src/Ra/GHC.hs-boot
+++ b/src/Ra/GHC.hs-boot
@@ -14,12 +14,13 @@ module Ra.GHC (
 import GHC
 import Data.Generics
 
-import Ra.Lang ( Stack, SymTable, PatMatchSyms, StackBranch )
+import Ra.Lang ( Sym, Stack, SymTable, PatMatchSyms, StackBranch )
 import Ra.Extra
 
 unHsWrap :: LHsExpr GhcTc -> LHsExpr GhcTc -- almost don't have to export this, except for legit use case for unwrapping `OpApp`s
 deapp :: LHsExpr GhcTc -> (LHsExpr GhcTc, [LHsExpr GhcTc])
-bind_to_table :: Stack -> HsBind GhcTc -> PatMatchSyms
+type Binds = [(Pat GhcTc, [Sym])]
+bind_to_table :: HsBind GhcTc -> Binds
 grhs_exprs :: GenericQ [LHsExpr GhcTc]
 grhs_binds :: Stack -> GenericQ PatMatchSyms
 mg_drop :: Int -> MatchGroup GhcTc (LHsExpr GhcTc) -> MatchGroup GhcTc (LHsExpr GhcTc)

--- a/src/Ra/Lang/Extra.hs
+++ b/src/Ra/Lang/Extra.hs
@@ -23,7 +23,7 @@ ppr_sa show' = go 0 where
           uncurry (++)
           . (
               uncurry (++) . (
-                  bool "" "*" . is_consumed . sa_sym
+                  bool "" "*" . not . null . sa_consumers
                   &&& ((indent ++ "<")++) . (show' . expr . sa_sym)
                 )
               &&& concatMap (

--- a/src/Ra/Lang/Extra.hs
+++ b/src/Ra/Lang/Extra.hs
@@ -3,6 +3,7 @@
 module Ra.Lang.Extra (
   ppr_sa,
   ppr_rs,
+  ppr_pms,
   ppr_stack
 ) where
 
@@ -28,7 +29,7 @@ ppr_sa show' = go 0 where
           . (
               uncurry (++) . (
                   bool "" "*" . not . null . sa_consumers
-                  &&& ((indent ++ "<")++) . (show' . expr . sa_sym)
+                  &&& ((indent ++ "<")++) . (show' . sa_sym)
                 )
               &&& concatMap (
                   (++("\n" ++ indent ++ " ]\n"))
@@ -42,7 +43,7 @@ ppr_writes :: Printer -> Writes -> String
 ppr_writes show' = concatMap ((++"\n---\n") . uncurry ((++) . (++" -> ")) . (show' *** concatMap ((++"\n") . ppr_sa show' . w_sym))) . assocs
 
 ppr_hold :: Printer -> Hold -> String
-ppr_hold show' = uncurry ((++) . (" <- "++)) . (show' . h_pat &&& ppr_sa show' . h_sym)
+ppr_hold show' = uncurry ((++) . (++" <- ")) . (show' . h_pat &&& ppr_sa show' . h_sym)
 
 ppr_rs :: Printer -> ReduceSyms -> String
 ppr_rs show' = flip concatMap printers . (("\n===\n"++).) . flip ($) where
@@ -55,7 +56,7 @@ ppr_rs show' = flip concatMap printers . (("\n===\n"++).) . flip ($) where
 ppr_pms :: Printer -> PatMatchSyms -> String
 ppr_pms show' = flip concatMap printers . (("\n===\n"++).) . flip ($) where
   printers = [
-      concatMap ((++"\n") . uncurry ((++) . (" -> "++)) . (show' *** concatMap ((++"\n") . ppr_sa show'))) . assocs . pms_syms
+      concatMap ((++"\n") . uncurry ((++) . (++" -> ")) . (show' *** concatMap ((++"\n") . ppr_sa show'))) . assocs . pms_syms
       , ppr_writes show' . pms_writes
       , concatMap ((++"\n---\n") . ppr_hold show') . pms_holds
     ]

--- a/src/Ra/Lang/Extra.hs
+++ b/src/Ra/Lang/Extra.hs
@@ -2,14 +2,18 @@
 
 module Ra.Lang.Extra (
   ppr_sa,
+  ppr_rs,
   ppr_stack
 ) where
 
 import GHC ( LHsExpr, GhcTc )
 import Data.Bool ( bool )
 import Data.Tuple.Extra ( (&&&), (***) )
-import Ra.Lang ( SymApp(..), Sym(..), unSB, Stack(..) )
+
+import Ra.Lang ( SymApp(..), Sym(..), unSB, Stack(..), ReduceSyms(..), PatMatchSyms(..), Hold(..), Write(..), Writes )
+
 import Outputable ( Outputable(..), showPpr )
+import Data.Map.Strict ( assocs )
 import qualified Data.Map.Strict as M ( map, elems, assocs )
 
 type Printer = (forall o. Outputable o => o -> String)
@@ -33,6 +37,28 @@ ppr_sa show' = go 0 where
                 ) . sa_args
             )
           )
+
+ppr_writes :: Printer -> Writes -> String
+ppr_writes show' = concatMap ((++"\n---\n") . uncurry ((++) . (++" -> ")) . (show' *** concatMap ((++"\n") . ppr_sa show' . w_sym))) . assocs
+
+ppr_hold :: Printer -> Hold -> String
+ppr_hold show' = uncurry ((++) . (" <- "++)) . (show' . h_pat &&& ppr_sa show' . h_sym)
+
+ppr_rs :: Printer -> ReduceSyms -> String
+ppr_rs show' = flip concatMap printers . (("\n===\n"++).) . flip ($) where
+  printers = [
+      concatMap ((++"\n") . ppr_sa show') . rs_syms
+      , ppr_writes show' . rs_writes
+      , concatMap ((++"\n---\n") . ppr_hold show') . rs_holds
+    ]
+
+ppr_pms :: Printer -> PatMatchSyms -> String
+ppr_pms show' = flip concatMap printers . (("\n===\n"++).) . flip ($) where
+  printers = [
+      concatMap ((++"\n") . uncurry ((++) . (" -> "++)) . (show' *** concatMap ((++"\n") . ppr_sa show'))) . assocs . pms_syms
+      , ppr_writes show' . pms_writes
+      , concatMap ((++"\n---\n") . ppr_hold show') . pms_holds
+    ]
 
 ppr_stack :: Printer -> Stack -> String
 ppr_stack show' = show . map (map (uncurry (++) . ((++"->") . show' *** concatMap (ppr_sa show'))) . M.assocs . snd) . unSB . st_branch

--- a/src/Rahse.bak.hs
+++ b/src/Rahse.bak.hs
@@ -50,7 +50,7 @@ module Rahse (
     in map ((flip App) args
   cov_ids HsApp l r = l_app l $ [cov_ids $ unLoc r] where
     l_app :: HsExpr GhcTc -> [[ReturnThing]] -> [ReturnThing]
-    l_app expr@(HsApp _ _) = l_app expr . (cov_ids r):
+    l_app expr@(HsApp _ _) = l_app (cov_ids r):
     l_app expr args = cov_ids expr & map $ \l_ret -> case l_ret of
       App { rt_left, rt_args } -> App rt_left (rt_args ++ args)
       _ -> App l_ret args

--- a/src/Rahse.hs
+++ b/src/Rahse.hs
@@ -50,7 +50,7 @@ module Rahse (
     in map ((flip App) args
   cov_ids HsApp l r = l_app l $ [cov_ids $ unLoc r] where
     l_app :: HsExpr GhcTc -> [[ReturnThing]] -> [ReturnThing]
-    l_app expr@(HsApp _ _) = l_app expr . (cov_ids r):
+    l_app expr@(HsApp _ _) = l_app (cov_ids r):
     l_app expr args = cov_ids expr & map $ \l_ret -> case l_ret of
       App { rt_left, rt_args } -> App rt_left (rt_args ++ args)
       _ -> App l_ret args

--- a/target/H.hs
+++ b/target/H.hs
@@ -2,8 +2,6 @@
 
 module H where
 import Control.Concurrent.MVar
-debug# :: a
-debug# = undefined
 
 type Consumer a b = a -> b
 
@@ -12,8 +10,11 @@ foo = do
   let x = 42
       y = bar x
   v <- newEmptyMVar
-  _ <- putMVar v y
-  readMVar v
+  w <- newEmptyMVar
+  _ <- putMVar w (v, 42)
+  _ <- putMVar v x
+  (p, _) <- readMVar w -- resolving from the wrong stack: may be from hold flagging (one breakpoint surprisingly not hit). OHHHHH. This is a fundamental flaw with the pattern matching scheme, which matches against only previous symbols, not symbols in the same group (thanks to `letrec`). Crap. BOOKMARK
+  readMVar p
 
 bar :: Consumer a a
 bar x = x

--- a/target/I.hs
+++ b/target/I.hs
@@ -1,0 +1,21 @@
+module I where
+  import Control.Concurrent.MVar
+  
+  data Z a b = Z a b
+  
+  foo =
+    let x = \a b -> a + b
+        z = if False then 42 else 56
+        a | False = 12
+          | True = a
+        c = Z a a
+        Z b _ = c
+        y = b
+    in do
+      v <- newEmptyMVar
+      putMVar v 42
+      return y
+  
+  -- foo = do
+  --   v <- newEmptyMVar
+  --   putMVar v 42


### PR DESCRIPTION
This branch has stabilized enough to lead stage 2 development.

It's been clear from the features that have been formulated and
implemented for this branch that several "state machines" of
sorts are necessary for correctness. Even in pure code,
mutually-recursive bindings require an arbitrary number of cycles
of pattern matching and substitution. The impure references add
another layer of state machine for resolving patterns that depend
on values exiting these references, which may themselves write
to references, also requiring an arbitrary number of unwrapping
cycles.