### PR TITLE
Roll SrcLoc anticycle mechanics and traversal bugfixes into main branch

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -23,13 +23,10 @@ module Main where
   import Ra.Lang.Extra
 
   import Outputable ( Outputable, interppSP, showSDocUnsafe, showPpr )
-
-  ppr :: Outputable a => a -> String
-  ppr = showSDocUnsafe . interppSP . pure
   
   ppr_branch :: StackBranch -> String
   ppr_branch = foldr (\case
-      AppFrame sa syms -> flip (foldr ((++) . (++"\n\n") . uncurry (++) . (((++", ") . ppr) *** concatMap (ppr . sa_sym)))) (M.assocs syms) . (++"---\n\n")
+      AppFrame sa syms -> flip (foldr ((++) . (++"\n\n") . uncurry (++) . (((++", ") . ppr_unsafe) *** concatMap (ppr_unsafe . sa_sym)))) (M.assocs $ stbl_table syms) . (++"---\n\n")
       _ -> id
     ) "" . unSB
 
@@ -51,9 +48,9 @@ module Main where
       t <- typecheckModule p
       
       let st0 = Stack (SB []) (SB [], SB [])
-          initial_pms = grhs_binds st0 (typecheckedSource t)
+          initial_pms = pat_match $ grhs_binds st0 (typecheckedSource t)
           syms0 = pms2rs initial_pms -- (\s -> s { sa_stack = append_frame (AppFrame s (pms_syms initial_pms)) (sa_stack s) }) $ head $ (!!0) $ M.elems $ 
       
-      -- return $ ppr_rs (showPpr dflags) $ reduce syms0
-      return $ ppr_pms (showPpr dflags) initial_pms
+      return $ uncurry (++) . (show *** ppr_rs (showPpr dflags)) $ reduce syms0
+      -- return $ ppr_pms (showPpr dflags) initial_pms
       -- return $ constr_ppr $ typecheckedSource t

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -23,7 +23,7 @@ module Main where
   import Ra.Lang.Extra
 
   import Outputable ( Outputable, interppSP, showSDocUnsafe, showPpr )
-  
+
   main :: IO ()
   main = do
     mod_str:_ <- getArgs
@@ -45,6 +45,7 @@ module Main where
           initial_pms = pat_match $ grhs_binds st0 (typecheckedSource t)
           syms0 = pms2rs initial_pms -- (\s -> s { sa_stack = append_frame (AppFrame s (pms_syms initial_pms)) (sa_stack s) }) $ head $ (!!0) $ M.elems $ 
       
+      -- return $ uncurry (++) . (show *** ppr_rs (showPpr dflags)) $ reduce $ (!!1) $ catMaybes $ map (\b -> case unLoc b of { AbsBinds {} -> Just $ snd $ head $ bind_to_table st0 (unLoc b); _ -> Nothing }) $ bagToList (typecheckedSource t)
       return $ uncurry (++) . (show *** ppr_rs (showPpr dflags)) $ reduce syms0
       -- return $ ppr_pms (showPpr dflags) initial_pms
       -- return $ constr_ppr $ typecheckedSource t

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -24,12 +24,6 @@ module Main where
 
   import Outputable ( Outputable, interppSP, showSDocUnsafe, showPpr )
   
-  ppr_branch :: StackBranch -> String
-  ppr_branch = foldr (\case
-      AppFrame sa syms -> flip (foldr ((++) . (++"\n\n") . uncurry (++) . (((++", ") . ppr_unsafe) *** concatMap (ppr_unsafe . sa_sym)))) (M.assocs $ stbl_table syms) . (++"---\n\n")
-      _ -> id
-    ) "" . unSB
-
   main :: IO ()
   main = do
     mod_str:_ <- getArgs

--- a/src/Ra.hs
+++ b/src/Ra.hs
@@ -96,28 +96,18 @@ pat_match_one pat sa =
       next_pms = mconcat $ map pat_match' (rs_syms nf_syms)
       pat_match' sa' = case pat of
         TuplePat _ pats _ ->
-          let matcher (SA _ _ _ (x:_)) = mempty -- error $ "Argument on explicit tuple. Perhaps a tuple section, which isn't supported yet. PPR:\n" ++ (ppr_sa ppr_unsafe sa')
-              matcher sa'' = case unLoc $ sa_sym sa'' of
-                ExplicitTuple _ args'' _ ->
-                  pat_multi_match (map unLoc pats) $ map ((\case
-                      Present _ expr -> [sa'' {
-                        sa_sym = expr,
-                        sa_args = []
-                      }] -- STACK good: this decomposition is not a function application so the stack stays the same
-                      -- NOTE this is the distributivity of `consumers` onto subdata of a datatype, as well as the stack
-                      -- NOTE encodes the assumption that we should preserve the original location of creation for this object, rather than this unravelling point because the datatype decompositions are trivial and can't define an object's identity
-                      Missing _ -> error "Tuple sections aren't supported yet."
-                    ) . unLoc) args''
-                _ -> Nothing
+          let matcher sa'' | TupleConstr _ <- sa_sym sa'' = pat_multi_match (map unLoc pats) (sa_args sa'')
+              matcher (SA _ _ _ (x:_)) = mempty -- error $ "Argument on explicit tuple. Perhaps a tuple section, which isn't supported yet. PPR:\n" ++ (ppr_sa ppr_unsafe sa')
               next_pms' = mconcat $ map matcher (rs_syms nf_syms) -- note the monoid definition of Maybe distributes the cat into ReduceSym `Just`s
           in (append_pms_writes (rs_writes nf_syms)) <$> next_pms'
           
         ConPatOut{ pat_con = L _ (RealDataCon pat_con'), pat_args = d_pat_args } -> case d_pat_args of
           PrefixCon pats ->
-            let matcher sa'' | (L _ (HsConLikeOut _ (RealDataCon con)), args'') <- deapp $ sa_sym sa'' -- sym' is in NF thanks to pat_multi_match; this assumes it
+            let matcher sa'' | (Sym sym) <- sa_sym sa''
+                             , (L _ (HsConLikeOut _ (RealDataCon con)), args'') <- deapp sym  -- sym' is in NF thanks to pat_multi_match; this assumes it
                              , dataConName con == dataConName pat_con' -- TEMP disable name matching on constructor patterns, to allow symbols to always be bound to everything
                               = let flat_args = ((map (\arg'' -> [sa'' {
-                                sa_sym = arg'',
+                                sa_sym = Sym arg'',
                                 sa_args = []
                               }]) args'') ++ sa_args sa'') -- STACK good: this decomposition is not a function application so the stack stays the same
                               -- NOTE this is the distributivity of `consumers` onto subdata of a datatype, as well as the stack
@@ -138,8 +128,8 @@ pat_match binds =
             args_changed = any (any (not . null . rs_syms)) m_next_args
             next_args = map (concatMap (uncurry list_alt . (rs_syms *** pure)) . uncurry zip) (zip m_next_args (sa_args sa)) -- encode law that arguments can fail to reduce and just fall back to the original form
             m_next_syms :: Maybe (Maybe ReduceSyms)
-            m_next_syms = case unLoc $ sa_sym sa of
-              HsVar _ (L _ v) -> if not $ v `elem` (var_ref_tail $ sa_stack sa)
+            m_next_syms = case sa_sym sa of
+              Sym (L _ (HsVar _ (L _ v))) -> if not $ v `elem` (var_ref_tail $ sa_stack sa)
                 then Just $
                   (
                       mconcat
@@ -215,9 +205,9 @@ reduce syms0 =
                           = [sa {
                              sa_args = next_args
                            }]
-            expanded = case unLoc $ sa_sym sa of
-              HsVar _ v -> case varString $ unLoc v of
-                "newEmptyMVar" -> fromMaybe mempty (map w_sym <$> ws !? make_stack_key sa)
+            expanded = case sa_sym sa of
+              Sym (L _ (HsVar _ v)) -> case varString $ unLoc v of
+                "newEmptyMVar" -> fromMaybe mempty (map (w_sym) <$> ws !? make_stack_key sa)
                 "readMVar" | length next_args > 0 -> head next_args -- list of pipes from the first arg
                 _ -> []
               _ -> []
@@ -258,7 +248,7 @@ reduce_deep :: SymApp -> ReduceSyms
 reduce_deep sa | let args = sa_args sa
                      sym = sa_sym sa
                , length args > 0 && is_zeroth_kind sym = error $ "Application on " ++ (show $ toConstr sym)
-reduce_deep sa@(SA consumers stack sym args) =
+reduce_deep sa@(SA consumers stack m_sym args) =
   -------------------
   -- SYM BASE CASE --
   -------------------
@@ -267,7 +257,7 @@ reduce_deep sa@(SA consumers stack sym args) =
       unravel1 :: LHsExpr GhcTc -> [[LHsExpr GhcTc]] -> ReduceSyms -- peeling back wrappings; consider refactor to evaluate most convenient type to put here
       unravel1 target new_args =
         let nf_new_args_syms = map (map (\arg -> reduce_deep $ sa {
-                sa_sym = arg,
+                sa_sym = Sym arg,
                 sa_args = []
               })) new_args
         in (mconcat $ mconcat nf_new_args_syms) {
@@ -275,187 +265,211 @@ reduce_deep sa@(SA consumers stack sym args) =
         } <> reduce_deep sa {
           -- STACK good: inherit from ambient application; if this ends up being an application, reduce_deep will update the stack accordingly
           -- CONSUMERS good: consumed law that distributes over unwrapping
-          sa_sym = target,
+          sa_sym = Sym target,
           sa_args = map (concatMap rs_syms) nf_new_args_syms
           -- CONSUMERS good: `consumers` property at least distributes over App; if the leftmost var is of type `Consumer`, then it might make some args `consumed` as well.
         }
       
-      fail = error $ "FAIL" ++ (constr_ppr $ sym)
-  in case unLoc sym of
-    HsLamCase _ mg -> unravel1 (HsLam NoExt mg <$ sym) []
-    
-    HsLam _ mg | let loc = getLoc $ mg_alts mg -- <- NB this is why the locations of MatchGroups don't matter
-               , not $ is_visited (st_branch stack) sa -> -- beware about `noLoc`s showing up here: maybe instead break out the pattern matching code
-                if matchGroupArity mg > length args
-                  then terminal
-                  else
-                    let pat_matches =
-                          (unLoc $ mg_alts mg) & mconcat . mconcat . map ( -- over function body alternatives
-                            map ( -- over arguments
-                              mconcat . catMaybes . map ( -- over possible expressions
-                                uncurry (flip pat_match_one) -- share the same stack
-                              ) . (uncurry zip) . (id *** repeat)
-                            ) . zip (sa_args sa) . map unLoc . m_pats . unLoc -- `args` FINALLY USED HERE
-                          ) -- NOTE no recursive pattern matching needed here because argument patterns are purely deconstructive and can't refer to the new bindings the others make
-                        
-                        bind_pms@(PatMatchSyms {
-                            pms_syms = next_explicit_binds,
-                            pms_writes = bind_writes
-                          }) = pat_match $ grhs_binds (append_frame (AppFrame sa mempty) stack) mg -- STACK questionable: do we need the new symbol here? Shouldn't it be  -- localize binds correctly via pushing next stack location
-                        next_exprs = grhs_exprs $ map (grhssGRHSs . m_grhss . unLoc) $ unLoc $ mg_alts mg
-                        next_frame = AppFrame sa (pms_syms pat_matches <> next_explicit_binds)
-                        next_stack = append_frame next_frame stack
-                        next_args = drop (matchGroupArity mg) args
-                    in mempty {
-                      rs_writes = pms_writes bind_pms <> pms_writes pat_matches
+      fail = error $ "FAIL" ++ (constr_ppr $ m_sym)
+  in case m_sym of
+    Sym sym -> case unLoc sym of
+      HsLamCase _ mg -> unravel1 (HsLam NoExt mg <$ sym) []
+      
+      HsLam _ mg | let loc = getLoc $ mg_alts mg -- <- NB this is why the locations of MatchGroups don't matter
+                 , not $ is_visited (st_branch stack) sa -> -- beware about `noLoc`s showing up here: maybe instead break out the pattern matching code
+                  if matchGroupArity mg > length args
+                    then terminal
+                    else
+                      let pat_matches =
+                            (unLoc $ mg_alts mg) & mconcat . mconcat . map ( -- over function body alternatives
+                              map ( -- over arguments
+                                mconcat . catMaybes . map ( -- over possible expressions
+                                  uncurry (flip pat_match_one) -- share the same stack
+                                ) . (uncurry zip) . (id *** repeat)
+                              ) . zip (sa_args sa) . map unLoc . m_pats . unLoc -- `args` FINALLY USED HERE
+                            ) -- NOTE no recursive pattern matching needed here because argument patterns are purely deconstructive and can't refer to the new bindings the others make
+                          
+                          bind_pms@(PatMatchSyms {
+                              pms_syms = next_explicit_binds,
+                              pms_writes = bind_writes
+                            }) = pat_match $ grhs_binds (append_frame (AppFrame sa mempty) stack) mg -- STACK questionable: do we need the new symbol here? Shouldn't it be  -- localize binds correctly via pushing next stack location
+                          next_exprs = grhs_exprs $ map (grhssGRHSs . m_grhss . unLoc) $ unLoc $ mg_alts mg
+                          next_frame = AppFrame sa (pms_syms pat_matches <> next_explicit_binds)
+                          next_stack = append_frame next_frame stack
+                          next_args = drop (matchGroupArity mg) args
+                      in mempty {
+                        rs_writes = pms_writes bind_pms <> pms_writes pat_matches
+                      }
+                        <> (mconcat $ map (\next_expr ->
+                            reduce_deep sa {
+                              sa_stack = next_stack,
+                              sa_sym = Sym next_expr,
+                              sa_args = next_args
+                            }
+                          ) next_exprs) -- TODO check if the sym record update + args are correct for this stage
+                 | otherwise -> mempty
+            
+      HsVar _ (L loc v) ->
+        let args' | arg1:rest <- args
+                  , Just "Consumer" <- varTyConName v
+                    = (map (\b -> b { sa_consumers = make_stack_key sa : (sa_consumers b) }) arg1) : rest -- identify as consumer-consumed values
+                     -- TODO refactor with lenses
+                  | otherwise = args
+        in (\rs@(ReduceSyms { rs_syms }) -> -- enforce nesting rule: all invokations on consumed values are consumed
+            rs {
+                rs_syms = map (\sa' -> sa' { sa_consumers = sa_consumers sa' ++ consumers }) rs_syms -- TODO <- starting to question if this is doubling work
+              }
+          ) $
+          if | v `elem` (var_ref_tail stack) ->
+                -- anti-cycle var resolution
+                mempty
+             | varString v == "debug#" ->
+                -- DEBUG SYMBOL
+                mempty
+             | Just left_syms <- stack_var_lookup True v stack -> -- this absolutely sucks, we have to use the "soft" search because instance name Uniques are totally unusable. Can't even use `Name`, unless I convert to string every time... which I might need to do in the future for performance reasons if I can't come up with a solution for this. 
+              mconcat $ map (\sa' ->
+                  reduce_deep sa' { -- TODO: check if `reduce_deep` is actually necessary here; might not be because we expect the symbols in the stack to be resolved
+                    sa_args = sa_args sa' ++ args', -- ARGS good: elements in the stack are already processed, so if their args are okay these ones are okay
+                    sa_stack = (sa_stack sa') {
+                      st_branch = mapSB ((VarRefFrame v):) (st_branch (sa_stack sa'))
                     }
-                      <> (mconcat $ map (\next_expr ->
-                          reduce_deep sa {
-                            sa_stack = next_stack,
-                            sa_sym = next_expr,
-                            sa_args = next_args
+                  }
+                ) left_syms
+             | otherwise -> case varString v of
+              ------------------------------------
+              -- *** SPECIAL CASE FUNCTIONS *** --
+              ------------------------------------
+              
+              -- "newEmptyMVar" -> -- return as terminal and identify above
+              -- "newMVar" -> -- find this in post-processing and do it
+              -- "takeMVar" -> if length args >= 1 -- no need, do this in post-processing
+              --   then 
+              --   else terminal
+              
+              -- MAGIC MONADS (fallthrough)
+              "return" | vs:args'' <- args' ->
+                mconcat $ map (\sa' -> reduce_deep $ sa' { sa_args = ((sa_args sa') <> args'') }) vs
+              -- NB about `[]` on the rightmost side of the pattern match on `args'`: it's never typesafe to apply to a monad (except `Arrow`), so if we see arguments, we have to freak out and not move forward with that.
+                
+              ">>" | i:o:[] <- args'
+                   , let i' = map reduce_deep i
+                         o' = map reduce_deep o -> -- magical monad `*>` == `>>`: take right-hand syms, merge writes
+                    mconcat [i'' { rs_syms = mempty } <> o'' | i'' <- i', o'' <- o'] -- combinatorial EXPLOSION! BOOM PEW PEW
+              ">>=" | i:o:[] <- args' -> -- magical monad `>>=`: shove the return value from the last stage into the next, merge writes
+                    -- grabbing the writes is as easy as just adding `i` to the arguments; the argument resolution in `terminal` will take care of it
+                    -- under the assumption that it's valid to assume IO is a pure wrapper, this actually just reduces to plain application of a lambda
+                      mconcat $ map (\fun -> reduce_deep fun {
+                            sa_args = sa_args fun ++ [i]
                           }
-                        ) next_exprs) -- TODO check if the sym record update + args are correct for this stage
-               | otherwise -> mempty
-          
-    HsVar _ (L loc v) ->
-      let args' | arg1:rest <- args
-                , Just "Consumer" <- varTyConName v
-                  = (map (\b -> b { sa_consumers = make_stack_key sa : (sa_consumers b) }) arg1) : rest -- identify as consumer-consumed values
-                   -- TODO refactor with lenses
-                | otherwise = args
-      in (\rs@(ReduceSyms { rs_syms }) -> -- enforce nesting rule: all invokations on consumed values are consumed
-          rs {
-              rs_syms = map (\sa' -> sa' { sa_consumers = sa_consumers sa' ++ consumers }) rs_syms -- TODO <- starting to question if this is doubling work
-            }
-        ) $
-        if | v `elem` (var_ref_tail stack) ->
-              -- anti-cycle var resolution
-              mempty
-           | varString v == "debug#" ->
-              -- DEBUG SYMBOL
-              mempty
-           | Just left_syms <- stack_var_lookup True v stack -> -- this absolutely sucks, we have to use the "soft" search because instance name Uniques are totally unusable. Can't even use `Name`, unless I convert to string every time... which I might need to do in the future for performance reasons if I can't come up with a solution for this. 
-            mconcat $ map (\sa' ->
-                reduce_deep sa' { -- TODO: check if `reduce_deep` is actually necessary here; might not be because we expect the symbols in the stack to be resolved
-                  sa_args = sa_args sa' ++ args', -- ARGS good: elements in the stack are already processed, so if their args are okay these ones are okay
-                  sa_stack = (sa_stack sa') {
-                    st_branch = mapSB ((VarRefFrame v):) (st_branch (sa_stack sa'))
-                  }
-                }
-              ) left_syms
-           | otherwise -> case varString v of
-            ------------------------------------
-            -- *** SPECIAL CASE FUNCTIONS *** --
-            ------------------------------------
-            
-            -- "newEmptyMVar" -> -- return as terminal and identify above
-            -- "newMVar" -> -- find this in post-processing and do it
-            -- "takeMVar" -> if length args >= 1 -- no need, do this in post-processing
-            --   then 
-            --   else terminal
-            
-            -- MAGIC MONADS (fallthrough)
-            "return" | vs:args'' <- args' ->
-              mconcat $ map (\sa' -> reduce_deep $ sa' { sa_args = ((sa_args sa') <> args'') }) vs
-            -- NB about `[]` on the rightmost side of the pattern match on `args'`: it's never typesafe to apply to a monad (except `Arrow`), so if we see arguments, we have to freak out and not move forward with that.
-              
-            ">>" | i:o:[] <- args'
-                 , let i' = map reduce_deep i
-                       o' = map reduce_deep o -> -- magical monad `*>` == `>>`: take right-hand syms, merge writes
-                  mconcat [i'' { rs_syms = mempty } <> o'' | i'' <- i', o'' <- o'] -- combinatorial EXPLOSION! BOOM PEW PEW
-            ">>=" | i:o:[] <- args' -> -- magical monad `>>=`: shove the return value from the last stage into the next, merge writes
-                  -- grabbing the writes is as easy as just adding `i` to the arguments; the argument resolution in `terminal` will take care of it
-                  -- under the assumption that it's valid to assume IO is a pure wrapper, this actually just reduces to plain application of a lambda
-                    mconcat $ map (\fun -> reduce_deep fun {
-                          sa_args = sa_args fun ++ [i]
-                        }
-                      ) o
-              
-            "forkIO" | to_fork:[] <- args' ->
-                let result = mconcat $ map (\sa' -> reduce_deep sa' {
-                        sa_stack = stack {
-                          st_thread = (st_branch stack, st_branch $ sa_stack sa')
-                        }
-                      }) to_fork
-                in result {
-                    rs_syms = [error "Using the ThreadID from forkIO is not yet supported."]
-                  }
-                  
-            "putMVar" -> if length args' >= 2
-              then
-                let (pipes:vals:_) = sa_args sa -- args' -- BOOKMARK args' and sa/terminal are incomparable: we lose the `consumed` property this way
-                    next_writes = map (\pipe -> case unLoc $ sa_sym pipe of
-                        HsVar _ v | varString (unLoc v) == "newEmptyMVar" -> singleton (make_stack_key pipe) $ map (\val -> Write stack val) vals
-                        _ -> mempty
-                      ) pipes
-                in terminal { -- this is a bit silly atm since terminal writes are empty, but not necessarily all the time
-                    rs_writes = unionsWith (++) (rs_writes terminal : next_writes)
-                  }
-              else terminal
-              
-            _ -> terminal
-      
-    HsApp _ _ _ -> -- this should only come up from the GHC AST, not from our own reduce-unwrap-wrap
-      let (fun, next_args) = deapp sym
-      in unravel1 fun (map pure next_args) -- I still don't remember why we special-cased HsConLikeOut to let it be `terminal` without evaluating the args, besides premature optimization  (i.e. saving the var lookup and one round of re-reducing the arguments)
-      
-    OpApp _ l_l l_op l_r -> unravel1 l_op [[l_l], [l_r]]
-    
-    -- Wrappings
-    HsWrap _ _ v -> unravel1 (const v <$> sym) [] -- why is HsWrap wrapping a bare HsExpr?! No loc? Inferred from surroundings I guess (like this)
-    NegApp _ v _ -> unravel1 v []
-    HsPar _ v -> unravel1 v []
-    SectionL _ v m_op -> unravel1 m_op [[v]]
-    SectionR _ m_op v | length args > 0 -> -- need to check fo arguments because that's the only way we're going to enforce the flipping
-                        let L _ (HsVar _ op) = unHsWrap m_op
-                            nf_arg1_syms = reduce_deep sa { sa_sym = v, sa_args = [] }
-                            arg0:args_rest = args
-                        in case stack_var_lookup True (unLoc op) stack of
-                          Just branch_exprs ->
-                            mappend nf_arg1_syms { rs_syms = [] } $ mconcat $ map (\sa' ->
-                              reduce_deep $ sa' {
-                                sa_args = (sa_args sa') ++ (arg0 : (rs_syms nf_arg1_syms) : args_rest) -- TODO also do the operator constructor case
-                              }
-                            ) branch_exprs
-                          Nothing -> terminal
-                      | otherwise -> error "Unsaturated (i.e. partial) SectionR is not yet supported."
+                        ) o
+                
+              "forkIO" | to_fork:[] <- args' ->
+                  let result = mconcat $ map (\sa' -> reduce_deep sa' {
+                          sa_stack = stack {
+                            st_thread = (st_branch stack, st_branch $ sa_stack sa')
+                          }
+                        }) to_fork
+                  in result {
+                      rs_syms = [error "Using the ThreadID from forkIO is not yet supported."]
+                    }
+                    
+              "putMVar" -> if length args' >= 2
+                then
+                  let (pipes:vals:_) = sa_args sa -- args' -- BOOKMARK args' and sa/terminal are incomparable: we lose the `consumed` property this way
+                      next_writes = map (\pipe -> case sa_sym pipe of
+                          Sym (L _ (HsVar _ v)) | varString (unLoc v) == "newEmptyMVar" -> singleton (make_stack_key pipe) $ map (\val -> Write (st_thread stack) val) vals
+                          _ -> mempty
+                        ) pipes
+                  in terminal { -- this is a bit silly atm since terminal writes are empty, but not necessarily all the time
+                      rs_writes = unionsWith (++) (rs_writes terminal : next_writes)
+                    }
+                else terminal
+                
+              _ -> terminal
         
-    HsCase _ x mg -> unravel1 (noLoc $ HsApp NoExt (HsLam NoExt mg <$ mg_alts mg) x) [] -- refactor as HsLam so we can just use that pat match code
-    HsIf _ _ if_ then_ else_ -> unravel1 then_ [] <> unravel1 else_ []
-    HsMultiIf ty rhss ->
-      let PatMatchSyms {
-              pms_syms = next_explicit_binds,
-              pms_writes = bind_writes
-            } = pat_match $ grhs_binds stack rhss
-          next_exprs = grhs_exprs rhss
-      in mempty { rs_writes = bind_writes }
-        <> (mconcat $ map (\next_expr ->
-            reduce_deep sa {
-              sa_sym = next_expr,
-              sa_stack = (stack { st_branch = mapSB ((AppFrame sa next_explicit_binds):) (st_branch stack) })
-            }) next_exprs) -- TODO check that record update with sym (and its location) is the right move here
+      HsApp _ _ _ -> -- this should only come up from the GHC AST, not from our own reduce-unwrap-wrap
+        let (fun, next_args) = deapp sym
+        in unravel1 fun (map pure next_args) -- I still don't remember why we special-cased HsConLikeOut to let it be `terminal` without evaluating the args, besides premature optimization  (i.e. saving the var lookup and one round of re-reducing the arguments)
+        
+      OpApp _ l_l l_op l_r -> unravel1 l_op [[l_l], [l_r]]
       
-    HsLet _ _ expr -> unravel1 expr [] -- assume local bindings already caught by surrounding function body (HsLam case)
-    HsDo _ _ (L _ stmts) -> foldl (\syms (L _ stmt) ->
-        case stmt of
-          LastStmt _ expr _ _ -> syms { rs_syms = mempty } <> unravel1 expr [] -- kill the results from all previous stmts because of the semantics of `>>`
-          -- ApplicativeStmt _ _ _ -> undefined -- TODO yet to appear in the wild and be implemented
-          BindStmt pat expr _ _ ty -> syms -- covered by binds; can't be the last statement anyways -- <- scratch that -- TODO implement this to unbox the monad (requires fake IO structure2) -- <- scratch THAT, we're not going to do anything because the binds are covered in grhs_binds; we're letting IO and other magic monads be unravelled into their values contained within to simplify analysis
-          LetStmt _ _ -> syms -- same story as BindStmt
-          BodyStmt _ expr _ _ -> syms { rs_syms = mempty } <> unravel1 expr []
-          ParStmt _ _ _ _ -> undefined -- not analyzed for now, because the list comp is too niche (only used for parallel monad comprehensions; see <https://gitlab.haskell.org/ghc/ghc/wikis/monad-comprehensions>)
-          _ -> fail
-          -- fun fact: I thought ParStmt was for "parenthesized", but it's "parallel"
-      ) mempty stmts -- push all the work to another round of `reduce_deep`.
-    
-    -- SymAppinal forms
-    
-    HsConLikeOut _ _ -> terminal -- if length args == 0 then terminal else error "Only bare ConLike should make it to `reduce_deep`" -- still don't remember why I special-cased HsConLikeOut in HsApp
-    HsOverLit _ _ -> terminal
-    HsLit _ _ -> terminal
-    ExplicitTuple _ _ _ -> terminal
-    ExplicitSum _ _ _ _ -> terminal
-    ExplicitList _ _ _ -> terminal
-    -- ExplicitPArr _ _ -> terminal
-    _ -> error ("Incomplete coverage of HsExpr rules: encountered " ++ (show $ toConstr $ unLoc sym))
+      -- Wrappings
+      HsWrap _ _ v -> unravel1 (const v <$> sym) [] -- why is HsWrap wrapping a bare HsExpr?! No loc? Inferred from surroundings I guess (like this)
+      NegApp _ v _ -> unravel1 v []
+      HsPar _ v -> unravel1 v []
+      SectionL _ v m_op -> unravel1 m_op [[v]]
+      SectionR _ m_op v | length args > 0 -> -- need to check fo arguments because that's the only way we're going to enforce the flipping
+                          let L _ (HsVar _ op) = unHsWrap m_op
+                              nf_arg1_syms = reduce_deep sa { sa_sym = Sym v, sa_args = [] }
+                              arg0:args_rest = args
+                          in case stack_var_lookup True (unLoc op) stack of
+                            Just branch_exprs ->
+                              mappend nf_arg1_syms { rs_syms = [] } $ mconcat $ map (\sa' ->
+                                reduce_deep $ sa' {
+                                  sa_args = (sa_args sa') ++ (arg0 : (rs_syms nf_arg1_syms) : args_rest) -- TODO also do the operator constructor case
+                                }
+                              ) branch_exprs
+                            Nothing -> terminal
+                        | otherwise -> error "Unsaturated (i.e. partial) SectionR is not yet supported."
+          
+      HsCase _ x mg -> unravel1 (noLoc $ HsApp NoExt (HsLam NoExt mg <$ mg_alts mg) x) [] -- refactor as HsLam so we can just use that pat match code
+      HsIf _ _ if_ then_ else_ -> unravel1 then_ [] <> unravel1 else_ []
+      HsMultiIf ty rhss ->
+        let PatMatchSyms {
+                pms_syms = next_explicit_binds,
+                pms_writes = bind_writes
+              } = pat_match $ grhs_binds stack rhss
+            next_exprs = grhs_exprs rhss
+        in mempty { rs_writes = bind_writes }
+          <> (mconcat $ map (\next_expr ->
+              reduce_deep sa {
+                sa_sym = Sym next_expr,
+                sa_stack = (stack { st_branch = mapSB ((AppFrame sa next_explicit_binds):) (st_branch stack) })
+              }) next_exprs) -- TODO check that record update with sym (and its location) is the right move here
+        
+      HsLet _ _ expr -> unravel1 expr [] -- assume local bindings already caught by surrounding function body (HsLam case)
+      HsDo _ _ (L _ stmts) -> foldl (\syms (L _ stmt) ->
+          case stmt of
+            LastStmt _ expr _ _ -> syms { rs_syms = mempty } <> unravel1 expr [] -- kill the results from all previous stmts because of the semantics of `>>`
+            -- ApplicativeStmt _ _ _ -> undefined -- TODO yet to appear in the wild and be implemented
+            BindStmt pat expr _ _ ty -> syms -- covered by binds; can't be the last statement anyways -- <- scratch that -- TODO implement this to unbox the monad (requires fake IO structure2) -- <- scratch THAT, we're not going to do anything because the binds are covered in grhs_binds; we're letting IO and other magic monads be unravelled into their values contained within to simplify analysis
+            LetStmt _ _ -> syms -- same story as BindStmt
+            BodyStmt _ expr _ _ -> syms { rs_syms = mempty } <> unravel1 expr []
+            ParStmt _ _ _ _ -> undefined -- not analyzed for now, because the list comp is too niche (only used for parallel monad comprehensions; see <https://gitlab.haskell.org/ghc/ghc/wikis/monad-comprehensions>)
+            _ -> fail
+            -- fun fact: I thought ParStmt was for "parenthesized", but it's "parallel"
+        ) mempty stmts -- push all the work to another round of `reduce_deep`.
+      
+      -- SymAppinal forms
+      
+      HsConLikeOut _ _ -> terminal -- if length args == 0 then terminal else error "Only bare ConLike should make it to `reduce_deep`" -- still don't remember why I special-cased HsConLikeOut in HsApp
+      HsOverLit _ _ -> terminal
+      HsLit _ _ -> terminal
+      ExplicitTuple _ args _ ->
+        let (next_rs, args') = first mconcat $ unzip $ map (\case
+                L _ (Present _ s) -> (id &&& rs_syms) $ reduce_deep $ sa {
+                    sa_sym = Sym s,
+                    sa_args = []
+                  }
+                _ -> error "Tuple sections not yet supported"
+              ) args
+        in next_rs { rs_syms = mempty } <> (reduce_deep $ sa {
+          sa_sym = TupleConstr (getLoc sym),
+          sa_args = args'
+        })
+      ExplicitSum _ _ _ _ -> terminal
+      ExplicitList _ _ args ->
+        let (next_rs, args') = first mconcat $ unzip $ map (\s ->
+                (id &&& rs_syms) $ reduce_deep $ sa {
+                  sa_sym = Sym s,
+                  sa_args = []
+                }
+              ) args
+        in next_rs { rs_syms = mempty } <> (reduce_deep $ sa {
+          sa_sym = ListConstr (getLoc sym),
+          sa_args = args'
+        })
+      ExplicitList _ (Just _) _ -> error "List comprehensions not yet supported"
+      -- ExplicitPArr _ _ -> terminal
+      _ -> error ("Incomplete coverage of HsExpr rules: encountered " ++ (show $ toConstr $ unLoc sym))
+    _ -> terminal

--- a/src/Ra/GHC.hs
+++ b/src/Ra/GHC.hs
@@ -48,11 +48,14 @@ deapp expr =
     HsApp _ l r -> (id *** (++[r])) (deapp l)
     _ -> (unwrapped, [])
 
-bind_to_table :: HsBind GhcTc -> Binds
-bind_to_table b = case b of
+bind_to_table :: Stack -> HsBind GhcTc -> Binds
+bind_to_table st b = case b of
   AbsBinds { abs_exports, abs_binds } ->
-    let subbinds = mconcat $ bagToList $ mapBag (bind_to_table . unLoc) abs_binds -- consider making union_sym_table just Foldable t => ...
-    in subbinds <> map (VarPat NoExt . noLoc . abe_poly &&& pure . noLoc . HsVar NoExt . noLoc . abe_mono) abs_exports
+    let subbinds = mconcat $ bagToList $ mapBag (bind_to_table st . unLoc) abs_binds
+    in subbinds <> map (
+        VarPat NoExt . noLoc . abe_poly
+        &&& reduce_deep . ((flip (SA [] st)) []) . noLoc . HsVar NoExt . noLoc . abe_mono
+      ) abs_exports
     
   -- AbsBindsSig { abs_sig_export, abs_sig_bind = L _ abs_sig_bind } -> 
   --   let subbinds = bind_to_table stack abs_sig_bind
@@ -63,10 +66,18 @@ bind_to_table b = case b of
   -------------------
   -- SYM BASE CASE --
   -------------------
-  FunBind { fun_id = fun_id, fun_matches } -> [( VarPat NoExt fun_id, [noLoc $ HsLam NoExt fun_matches] )]
+  FunBind { fun_id = fun_id, fun_matches } -> [(
+      VarPat NoExt fun_id,
+      mempty {
+        rs_syms = [SA [] st (noLoc $ HsLam NoExt fun_matches) []]
+      }
+    )]
   
   PatBind { pat_lhs = L _ pat_lhs, pat_rhs } ->
-    grhs_binds' pat_rhs <> [(pat_lhs, grhs_exprs pat_rhs)]
+    grhs_binds st pat_rhs <> [(
+        pat_lhs,
+        mconcat $ map (reduce_deep . flip (SA [] st) []) (grhs_exprs pat_rhs)
+      )]
   VarBind{} -> mempty
   _ -> error $ constr_ppr b
 
@@ -75,65 +86,12 @@ bind_to_table b = case b of
 grhs_exprs :: GenericQ [LHsExpr GhcTc]
 grhs_exprs x = map (\(L _ (GRHS _ _ body) :: LGRHS GhcTc (LHsExpr GhcTc)) -> body) (concat $ shallowest cast x)
 
-type Binds = [(Pat GhcTc, [Sym])]
-grhs_binds :: Stack -> GenericQ PatMatchSyms
-grhs_binds st z =
-  let binds = grhs_binds' z
-      sub :: SymTable -> SymApp -> [SymApp]
-      sub t sa =
-        let m_next_args = map (map (sub t)) (sa_args sa)
-            args_changed = any (any (not . null)) m_next_args
-            next_args = map (concatMap (uncurry list_alt . second pure) . uncurry zip) (zip m_next_args (sa_args sa)) -- encode law that arguments can fail to reduce and just fall back to the original form
-            m_next_syms :: Maybe (Maybe [SymApp])
-            -- the only case where the iteration moves forward is when the matching finds a symbol that isn't just references to other symbols after reduction. `sub` could communicate this by just returning new symbols. Still ambiguous on the meaning if we succeed on some bare arguments. But by pattern matching, this could yield new things if the only path to that new binding was through that route, so arguments are preserved if they fail, as opposed to failing the whole block; only if all arguments fail and the symbol resolution fails, basically if _anything_ makes any progress, then we're good
-            m_next_syms = case unLoc $ sa_sym sa of
-              HsVar _ (L _ v) -> if not $ v `elem` (var_ref_tail $ sa_stack sa)
-                then Just $
-                  (
-                      uncurry list_alt
-                      . (concatMap (sub t) &&& id)
-                      . map (\sa' ->
-                          sa' {
-                            sa_stack = append_frame (VarRefFrame v) (sa_stack sa'),
-                            sa_args = (sa_args sa') <> next_args
-                          }
-                        )
-                    )
-                  <$> (t !? v)
-                else Nothing
-              _ -> Just Nothing
-        in fromMaybe [] (fromMaybe (
-            if args_changed
-              then [sa { sa_args = next_args }]
-              else [] -- encode the law that if all arguments have failed and the sym has also failed, this whole match fails
-          ) <$> m_next_syms) -- encode the law that if this is a var reduction cycle, then the result is empty
-      
-      -- BOOKMARK need reduce_deep here, maybe strip away from pat_match for performance later
-      
-      iterant :: [(Pat GhcTc, [SymApp])] -> PatMatchSyms -> (Bool, ([(Pat GhcTc, [SymApp])], PatMatchSyms))
-      iterant binds' pms =
-        let next_pms = fromMaybe mempty $ mconcat $ map (mconcat . uncurry map . first pat_match) binds'
-            syms = map snd binds'
-            m_next_syms = map (map (sub (pms_syms next_pms))) syms
-            changed = any (any (not . null)) m_next_syms
-            next_syms = map (uncurry $ second . ((concatMap (uncurry list_alt . second pure)).) . zip) (zip m_next_syms binds')
-        in (not changed, (next_syms, (pms <> next_pms) {
-          pms_syms = pms_syms next_pms `map_alt` pms_syms pms
-        })) -- look for if `<>` is the right thing to do on this pms chain
-      binds0 = map (second (mconcat . map (reduce_deep . (flip (SA [] st) [])))) binds
-      syms0 = mconcat $ map snd binds0
-      symsn = snd $ snd $ until fst (uncurry iterant . snd) (False, (map (second rs_syms) binds0, mempty))
-  in symsn { -- BOOKMARK this initial condition is really ugly
-      pms_holds = pms_holds symsn <> rs_holds syms0,
-      pms_writes = pms_writes symsn <> rs_writes syms0
-    }
-
-grhs_binds' :: GenericQ Binds -- TODO consider passing more info via `GenericQ (Maybe PatMatchSyms)`, and removing the fromMaybe
-grhs_binds' = everythingBut (<>) (
+grhs_binds :: Stack -> GenericQ Binds -- TODO consider passing more info via `GenericQ (Maybe PatMatchSyms)`, and removing the fromMaybe
+grhs_binds st = everythingBut (<>) (
     (mempty, False)
-    `mkQ` ((,True) . bind_to_table)
+    `mkQ` ((,True) . bind_to_table st)
     `extQ` ((,False) . ((\case
-        BindStmt _ (L _ pat) expr _ _ -> [(pat, [expr])] -- TODO check if a fresh stack key here is the right thing to do
+        BindStmt _ (L _ pat) expr _ _ -> [(pat, reduce_deep (SA [] st expr []))]
         _ -> mempty
       ) . unLoc :: LStmt GhcTc (LHsExpr GhcTc) -> Binds)) -- TODO dangerous: should we really keep looking deeper after finding a BindStmt?
     `extQ` ((mempty,) . ((\case 

--- a/src/Ra/GHC.hs-boot
+++ b/src/Ra/GHC.hs-boot
@@ -14,15 +14,14 @@ module Ra.GHC (
 import GHC
 import Data.Generics
 
-import Ra.Lang ( Sym, Stack, SymTable, PatMatchSyms, StackBranch )
+import Ra.Lang ( Sym, Stack, SymTable, PatMatchSyms, StackBranch, Binds )
 import Ra.Extra
 
 unHsWrap :: LHsExpr GhcTc -> LHsExpr GhcTc -- almost don't have to export this, except for legit use case for unwrapping `OpApp`s
 deapp :: LHsExpr GhcTc -> (LHsExpr GhcTc, [LHsExpr GhcTc])
-type Binds = [(Pat GhcTc, [Sym])]
-bind_to_table :: HsBind GhcTc -> Binds
+bind_to_table :: Stack -> HsBind GhcTc -> Binds
 grhs_exprs :: GenericQ [LHsExpr GhcTc]
-grhs_binds :: Stack -> GenericQ PatMatchSyms
+grhs_binds :: Stack -> GenericQ Binds
 mg_drop :: Int -> MatchGroup GhcTc (LHsExpr GhcTc) -> MatchGroup GhcTc (LHsExpr GhcTc)
 mg_flip :: MatchGroup GhcTc (LHsExpr GhcTc) -> MatchGroup GhcTc (LHsExpr GhcTc)
 varString :: Id -> String

--- a/src/Ra/GHC.hs-boot
+++ b/src/Ra/GHC.hs-boot
@@ -14,14 +14,14 @@ module Ra.GHC (
 import GHC
 import Data.Generics
 
-import Ra.Lang ( Sym, Stack, SymTable, PatMatchSyms, StackBranch, Binds )
+import Ra.Lang ( Sym, Stack, SymTable, PatMatchSyms, StackBranch, Bind )
 import Ra.Extra
 
 unHsWrap :: LHsExpr GhcTc -> LHsExpr GhcTc -- almost don't have to export this, except for legit use case for unwrapping `OpApp`s
 deapp :: LHsExpr GhcTc -> (LHsExpr GhcTc, [LHsExpr GhcTc])
-bind_to_table :: Stack -> HsBind GhcTc -> Binds
+bind_to_table :: Stack -> HsBind GhcTc -> [Bind]
 grhs_exprs :: GenericQ [LHsExpr GhcTc]
-grhs_binds :: Stack -> GenericQ Binds
+grhs_binds :: Stack -> GenericQ [Bind]
 mg_drop :: Int -> MatchGroup GhcTc (LHsExpr GhcTc) -> MatchGroup GhcTc (LHsExpr GhcTc)
 mg_flip :: MatchGroup GhcTc (LHsExpr GhcTc) -> MatchGroup GhcTc (LHsExpr GhcTc)
 varString :: Id -> String

--- a/src/Ra/Lang/Extra.hs
+++ b/src/Ra/Lang/Extra.hs
@@ -6,7 +6,8 @@ module Ra.Lang.Extra (
   ppr_rs,
   ppr_pms,
   ppr_stack,
-  ppr_branch
+  ppr_branch,
+  ppr_writes
 ) where
 
 import GHC ( LHsExpr, GhcTc )
@@ -48,8 +49,8 @@ ppr_sa show' = go 0 where
 ppr_writes :: Printer -> Writes -> String
 ppr_writes show' = concatMap ((++"\n---\n") . uncurry ((++) . (++" -> ")) . (show' *** concatMap ((++"\n") . ppr_sa show' . w_sym))) . assocs
 
-ppr_hold :: Printer -> Hold -> String
-ppr_hold show' = uncurry ((++) . (++" <- ")) . (show' . h_pat &&& ppr_sa show' . h_sym)
+-- ppr_hold :: Printer -> Hold -> String
+-- ppr_hold show' = uncurry ((++) . (++" <- ")) . (show' . h_pat &&& ppr_sa show' . h_sym)
 
 ppr_rs :: Printer -> ReduceSyms -> String
 ppr_rs show' = flip concatMap printers . (("\n===\n"++).) . flip ($) where

--- a/src/Ra/Lang/Extra.hs
+++ b/src/Ra/Lang/Extra.hs
@@ -5,7 +5,8 @@ module Ra.Lang.Extra (
   ppr_sa,
   ppr_rs,
   ppr_pms,
-  ppr_stack
+  ppr_stack,
+  ppr_branch
 ) where
 
 import GHC ( LHsExpr, GhcTc )
@@ -39,7 +40,7 @@ ppr_sa show' = go 0 where
                       . (("\n" ++ indent ++ " (\n")++)
                       . concatMap (go (n+1))
                     ) . sa_args
-                  &&& show' . make_stack_key . sa_stack
+                  &&& show' . make_stack_key
                 )
             )
           )
@@ -78,6 +79,12 @@ ppr_stack show' =
           ) (M.assocs $ stbl_table af_syms))
       VarRefFrame v -> show' v
     ) . unSB . st_branch
+
+ppr_branch :: Printer -> StackBranch -> String
+ppr_branch show' = foldr (\case
+    AppFrame sa syms -> flip (foldr ((++) . (++"\n\n") . uncurry (++) . (((++", ") . show') *** concatMap (show' . sa_sym)))) (M.assocs $ stbl_table syms) . (++"---\n\n")
+    _ -> id
+  ) "" . unSB
 
 ppr_unsafe :: Outputable a => a -> String
 ppr_unsafe = showSDocUnsafe . interppSP . pure

--- a/target/H.hs
+++ b/target/H.hs
@@ -8,7 +8,7 @@ type Consumer a b = a -> b
 foo :: IO Int
 foo = do
   let x = 42
-      y = bar x
+      y = x
   v <- newEmptyMVar
   w <- newEmptyMVar
   _ <- putMVar w (v, 42)

--- a/target/J.hs
+++ b/target/J.hs
@@ -1,0 +1,8 @@
+module J where
+  import Control.Concurrent.MVar
+  
+  foo = do
+    v <- newEmptyMVar
+    putMVar v ((), 42)
+    b <- readMVar v
+    return b

--- a/target/K.hs
+++ b/target/K.hs
@@ -1,0 +1,7 @@
+module K where
+
+import Control.Concurrent.MVar
+
+foo = do
+  j <- readMVar undefined
+  return j


### PR DESCRIPTION
The branch is starting to bloat with fixes and become irrelevant to its original purpose, but these fixes are important and now intrinsically tied to the anticycle scheme. Until it fails (which remains to be seen; its tests for failure were incidentally contingent on these fixes themselves) we'll keep using this simpler and easier-to-debug scheme.