### PR TITLE
Make pattern matching generic and more correct

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -10,7 +10,7 @@ module Main where
   import Bag ( bagToList )
   import qualified Data.Map.Strict as M
   import Data.Map.Strict ( unionsWith, keys, toList )
-  import Data.Generics ( cast, mkQ, extQ, everything, toConstr, Data(..) )
+  import Data.Generics ( cast, mkT, mkQ, extQ, everything, everywhere, everywhereBut, toConstr, Data(..) )
   import Data.Generics.Extra ( constr_ppr, shallowest, everything_ppr )
   import qualified Data.Map.Strict as M ( empty, elems )
   import Data.Tuple.Extra ( first, (&&&), (***) )
@@ -19,7 +19,7 @@ module Main where
   
   import Ra ( pat_match, reduce, reduce_deep )
   import Ra.GHC ( bind_to_table, grhs_binds )
-  import Ra.Lang -- ( SymTable, Sym(..), SymApp(..), StackBranch(..), unSB, Stack(..), ReduceSyms(..), PatMatchSyms(..), Write(..) )
+  import Ra.Lang -- ( SymTable, Sym(..), SymApp(..), Stack(..), unSB, Stack(..), ReduceSyms(..), PatMatchSyms(..), Write(..) )
   import Ra.Lang.Extra
 
   import Outputable ( Outputable, interppSP, showSDocUnsafe, showPpr )
@@ -41,12 +41,16 @@ module Main where
       p <- parseModule modSum
       t <- typecheckModule p
       
-      let st0 = Stack (SB []) (SB [], SB [])
-          initial_pms = pat_match $ grhs_binds st0 (typecheckedSource t)
+      let st0 = SB []
+          initial_pms = pat_match $ grhs_binds (typecheckedSource t)
           syms0 = pms2rs initial_pms -- (\s -> s { sa_stack = append_frame (AppFrame s (pms_syms initial_pms)) (sa_stack s) }) $ head $ (!!0) $ M.elems $ 
+          syms1 = everywhere (mkT (\sa -> sa {
+              sa_stack = mapSB ((AppFrame (sa_from_sym EntryPoint) (pms_syms initial_pms)): ) (sa_stack sa)
+            })) syms0 -- this makes it work, but feels verrrrry sketchy modifying stacks like that; it's almost like duplicating and tacking onto this "layer"
       
       -- return $ uncurry (++) . (show *** ppr_rs (showPpr dflags)) $ reduce $ (!!1) $ catMaybes $ map (\b -> case unLoc b of { AbsBinds {} -> Just $ snd $ head $ bind_to_table st0 (unLoc b); _ -> Nothing }) $ bagToList (typecheckedSource t)
-      return $ uncurry (++) . (show *** ppr_rs (showPpr dflags)) $ reduce syms0
+      return $ uncurry (++) . (show *** ppr_rs (showPpr dflags)) $ reduce syms1
       -- return $ concatMap ((++"\n") . uncurry ((++) . (++" -> ")) . (showPpr dflags *** concatMap (ppr_stack (showPpr dflags) . sa_stack))) $ M.assocs $ stbl_table (pms_syms initial_pms)
       -- return $ ppr_pms (showPpr dflags) initial_pms
+      -- return $ concatMap (uncurry (++) . ((showPpr dflags) *** (concatMap (ppr_sa (showPpr dflags))))) $ grhs_binds (typecheckedSource t)
       -- return $ constr_ppr $ typecheckedSource t

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -49,7 +49,8 @@ module Main where
             })) syms0 -- this makes it work, but feels verrrrry sketchy modifying stacks like that; it's almost like duplicating and tacking onto this "layer"
       
       -- return $ uncurry (++) . (show *** ppr_rs (showPpr dflags)) $ reduce $ (!!1) $ catMaybes $ map (\b -> case unLoc b of { AbsBinds {} -> Just $ snd $ head $ bind_to_table st0 (unLoc b); _ -> Nothing }) $ bagToList (typecheckedSource t)
-      return $ uncurry (++) . (show *** ppr_rs (showPpr dflags)) $ reduce syms1
+      -- return $ ppr_rs (showPpr dflags) syms0
+      return $ uncurry (++) . (show *** ppr_rs (showPpr dflags)) $ reduce syms0
       -- return $ concatMap ((++"\n") . uncurry ((++) . (++" -> ")) . (showPpr dflags *** concatMap (ppr_stack (showPpr dflags) . sa_stack))) $ M.assocs $ stbl_table (pms_syms initial_pms)
       -- return $ ppr_pms (showPpr dflags) initial_pms
       -- return $ concatMap (uncurry (++) . ((showPpr dflags) *** (concatMap (ppr_sa (showPpr dflags))))) $ grhs_binds (typecheckedSource t)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -14,7 +14,7 @@ module Main where
   import Data.Generics.Extra ( constr_ppr, shallowest, everything_ppr )
   import qualified Data.Map.Strict as M ( empty, elems )
   import Data.Tuple.Extra ( first, (&&&), (***) )
-  import Data.Maybe ( fromMaybe )
+  import Data.Maybe ( fromMaybe, catMaybes )
   import Control.Monad ( mzero )
   
   import Ra ( pat_match, reduce, reduce_deep )
@@ -47,5 +47,6 @@ module Main where
       
       -- return $ uncurry (++) . (show *** ppr_rs (showPpr dflags)) $ reduce $ (!!1) $ catMaybes $ map (\b -> case unLoc b of { AbsBinds {} -> Just $ snd $ head $ bind_to_table st0 (unLoc b); _ -> Nothing }) $ bagToList (typecheckedSource t)
       return $ uncurry (++) . (show *** ppr_rs (showPpr dflags)) $ reduce syms0
+      -- return $ concatMap ((++"\n") . uncurry ((++) . (++" -> ")) . (showPpr dflags *** concatMap (ppr_stack (showPpr dflags) . sa_stack))) $ M.assocs $ stbl_table (pms_syms initial_pms)
       -- return $ ppr_pms (showPpr dflags) initial_pms
       -- return $ constr_ppr $ typecheckedSource t

--- a/src/Ra.hs
+++ b/src/Ra.hs
@@ -139,7 +139,7 @@ pat_match binds =
                   <$> (t !? v)
                 else Nothing
               _ -> Nothing
-        in snd ((t, sa), fromMaybe mempty m_next_syms)
+        in fromMaybe mempty m_next_syms
       
       iterant :: PatMatchSyms -> (Bool, PatMatchSyms)
       iterant pms =
@@ -163,7 +163,8 @@ pat_match binds =
           )
       
       (rs0, binds0) = first mconcat $ unzip $ map ((\(pat, rs) -> (rs, (pat, rs_syms rs))) . second (mconcat . map reduce_deep)) binds -- [(Pat, ReduceSyms)] => [(ReduceSyms, (Pat, [SymApp]))] => ([ReduceSyms], [(Pat, SymApp)])
-      (_, pmsn) = until fst (iterant . snd) (False, mempty {
+      (_, pmsn) = until fst (iterant . snd) (False, PatMatchSyms {
+            pms_writes = rs_writes rs0,
             pms_syms = mempty {
               stbl_binds = binds0
             }
@@ -171,8 +172,7 @@ pat_match binds =
     in pmsn {
       pms_syms = (pms_syms pmsn) {
         stbl_table = pat_match_many (stbl_binds $ pms_syms pmsn)
-      },
-      pms_writes = pms_writes pmsn <> rs_writes rs0
+      }
     }
 
 reduce :: ReduceSyms -> (Int, ReduceSyms)

--- a/src/Ra.hs
+++ b/src/Ra.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NamedFieldPuns, LambdaCase, TupleSections, MultiWayIf #-}
+{-# LANGUAGE NamedFieldPuns, LambdaCase, TupleSections, MultiWayIf, DeriveDataTypeable #-}
 module Ra (
   pat_match,
   reduce_deep,
@@ -25,11 +25,12 @@ import Data.Tuple ( swap )
 import Data.Tuple.Extra ( first, second, (***), (&&&), both )
 import Data.Function ( (&) )
 import Data.Maybe ( catMaybes, fromMaybe, maybeToList, isNothing )
-import Data.Data ( toConstr )
-import Data.Generics.Extra ( constr_ppr )
+import Data.Data ( toConstr, Data(..), Typeable(..) )
+import Data.Generics ( everywhereBut, mkQ, mkT, extQ )
+import Data.Generics.Extra ( constr_ppr, everywhereWithContextBut, extQT, mkQT )
 import Data.Semigroup ( (<>) )
 import Data.Monoid ( mempty, mconcat )
-import Control.Monad ( guard )
+import Control.Monad ( guard, foldM )
 import Control.Applicative ( (<|>), liftA2 )
 import Control.Exception ( assert )
 
@@ -46,25 +47,28 @@ import Ra.Extra
 import Ra.Lang.Extra
 import Ra.Refs ( write_funs, read_funs )
 
-pat_multi_match ::
+pat_match_zip ::
   [Pat GhcTc]
   -> [[SymApp]]
-  -> Maybe PatMatchSyms
-pat_multi_match pats args =
-  let matches = map (uncurry ((mconcat.) . map . pat_match_one)) (zip pats args)
-  in foldl1 (<>) matches
+  -> Maybe (Map Id [SymApp])
+pat_match_zip pats args =
+  foldM (
+      curry $ uncurry fmap . (
+          unionWith (++)
+          *** uncurry ((mconcat.) . map . pat_match_one) -- Maybe (Map Id [SymApp]), with OR mechanics: if one arg alternative fails, the others will try to take its place
+        )
+    ) mempty $ zip pats args
 
 pat_match_one ::
   Pat GhcTc
   -> SymApp
-  -> Maybe PatMatchSyms
+  -> Maybe (Map Id [SymApp])
 pat_match_one pat sa =
-  let nf_syms = reduce_deep sa
-  in case pat of
+  case pat of
     ---------------------------------
     -- *** UNWRAPPING PATTERNS *** --
     ---------------------------------
-    WildPat ty -> Just $ mempty { pms_writes = rs_writes nf_syms } -- TODO check if this is the right [write, haha] behavior
+    WildPat ty -> Just mempty -- TODO check if this is the right [write, haha] behavior
       
     -- Wrappers --
     LazyPat _ (L _ pat) -> pat_match_one pat sa
@@ -73,123 +77,103 @@ pat_match_one pat sa =
     -- SigPatOut (L _ pat) _ -> pat_match_one pat sa
     
     -- Bases --
-    VarPat _ (L _ v) -> Just $ mempty {
-        pms_syms = mempty { stbl_table = singleton v (rs_syms nf_syms) },
-        pms_writes = rs_writes nf_syms
-      }
+    VarPat _ (L _ v) -> Just $ singleton v [sa]
     LitPat _ _ -> Just mempty -- no new name bindings
     NPat _ _ _ _ -> Just mempty
     
     -- Containers --
-    ListPat _ pats -> mconcat $ map (\(L _ pat') -> pat_match_one pat' sa) pats -- encodes the logic that all elements of a list might be part of the pattern regardless of order
+    ListPat _ pats -> undefined -- need to use pat_match_zip
+    -- ListPat _ pats -> unionsWith (++) $ map (\(L _ pat') -> pat_match_one pat' sa) pats -- encodes the logic that all elements of a list might be part of the pattern regardless of order
     AsPat _ (L _ bound) (L _ pat') -> -- error "At patterns (@) aren't yet supported."
       let matches = pat_match_one pat' sa
-      in (mappend (mempty { pms_syms = mempty { stbl_table = singleton bound [sa] } })) <$> matches -- note: `at` patterns can't be formally supported, because they might contain sub-patterns that need to hold. They also violate the invariant that "held" pattern targets have a read operation on their surface. However, since this only makes the test _less sensitive_, we'll try as hard as we can and just miss some things later.
+      in (unionWith (++) $ singleton bound [sa]) <$> matches -- note: `at` patterns can't be formally supported, because they might contain sub-patterns that need to hold. They also violate the invariant that "held" pattern targets have a read operation on their surface. However, since this only makes the test _less sensitive_, we'll try as hard as we can and just miss some things later.
         -- TODO test this: the outer binding and inner pattern are related: the inner pattern must succeed for the outer one to as well.
         
     -------------------------------
     -- *** MATCHING PATTERNS *** --
     -------------------------------
-    _ -> fmap (\pms -> pms { -- TODO consider generic joining function
-      pms_writes = pms_writes pms <> rs_writes nf_syms
-    }) next_pms where
-      next_pms = mconcat $ map pat_match' (rs_syms nf_syms)
-      pat_match' sa' = case pat of
-        TuplePat _ pats _ ->
-          let matcher sa'' | TupleConstr _ <- sa_sym sa'' = pat_multi_match (map unLoc pats) (sa_args sa'')
-              matcher (SA _ _ _ (x:_)) = mempty -- error $ "Argument on explicit tuple. Perhaps a tuple section, which isn't supported yet. PPR:\n" ++ (ppr_sa ppr_unsafe sa')
-              next_pms' = mconcat $ map matcher (rs_syms nf_syms) -- note the monoid definition of Maybe distributes the cat into ReduceSym `Just`s
-          in (append_pms_writes (rs_writes nf_syms)) <$> next_pms'
-          
-        ConPatOut{ pat_con = L _ (RealDataCon pat_con'), pat_args = d_pat_args } -> case d_pat_args of
-          PrefixCon pats ->
-            let matcher sa'' | (Sym sym) <- sa_sym sa''
-                             , (L _ (HsConLikeOut _ (RealDataCon con)), args'') <- deapp sym  -- sym' is in NF thanks to pat_multi_match; this assumes it
-                             , dataConName con == dataConName pat_con' -- TEMP disable name matching on constructor patterns, to allow symbols to always be bound to everything
-                              = let flat_args = ((map (\arg'' -> [sa'' {
-                                sa_sym = Sym arg'',
-                                sa_args = []
-                              }]) args'') ++ sa_args sa'') -- STACK good: this decomposition is not a function application so the stack stays the same
-                              -- NOTE this is the distributivity of `consumers` onto subdata of a datatype, as well as the stack
-                                in pat_multi_match (map unLoc pats) flat_args
-                             | otherwise = Nothing
-                next_pms' = mconcat $ map matcher (rs_syms nf_syms)
-            in (append_pms_writes (rs_writes nf_syms)) <$> next_pms'
-        
-          RecCon _ -> error "Record syntax yet to be implemented"
-          
-        _ -> error $ constr_ppr pat
-        
+    TuplePat _ pats _ | TupleConstr _ <- sa_sym sa -> pat_match_zip (map unLoc pats) (sa_args sa)
+                      | otherwise -> mempty -- error $ "Argument on explicit tuple. Perhaps a tuple section, which isn't supported yet. PPR:\n" ++ (ppr_sa ppr_unsafe sa)
+                      
+    ConPatOut{ pat_con = L _ (RealDataCon pat_con'), pat_args = d_pat_args } -> case d_pat_args of
+      PrefixCon pats | (Sym sym) <- sa_sym sa
+                     , (L _ (HsConLikeOut _ (RealDataCon con)), args'') <- deapp sym
+                     , dataConName con == dataConName pat_con' -- TEMP disable name matching on constructor patterns, to allow symbols to always be bound to everything
+                     -> let flat_args = ((map (\arg'' -> [sa {
+                        sa_sym = Sym arg'',
+                        sa_args = []
+                      }]) args'') ++ sa_args sa) -- STACK good: this decomposition is not a function application so the stack stays the same
+                          -- NOTE this is the distributivity of `consumers` onto subdata of a datatype, as well as the stack
+                            in pat_match_zip (map unLoc pats) flat_args
+                     | otherwise -> Nothing
+    
+      RecCon _ -> error "Record syntax yet to be implemented"
+      
+    _ -> error $ constr_ppr pat
+
+newtype Q a b = Q (Maybe (a, b)) deriving (Data, Typeable)
+unQ (Q z) = z
+
+pat_match_many :: [Bind] -> Map Id [SymApp]
+pat_match_many = unionsWith (++) . map (unionsWith (++)) . map (catMaybes . uncurry map . first pat_match_one)
+
 pat_match :: [Bind] -> PatMatchSyms
 pat_match binds = 
-  let sub :: SymTable -> SymApp -> ReduceSyms
-      sub t sa =
-        let m_next_args = map (map (sub t)) (sa_args sa)
-            args_changed = any (any (not . null . rs_syms)) m_next_args
-            next_args = map (concatMap (uncurry list_alt . (rs_syms *** pure)) . uncurry zip) (zip m_next_args (sa_args sa)) -- encode law that arguments can fail to reduce and just fall back to the original form
-            m_next_syms :: Maybe (Maybe ReduceSyms)
+  let sub :: Map Id [SymApp] -> SymApp -> ReduceSyms
+      sub t sa = -- assumes incoming term is a normal form
+        let m_next_syms :: Maybe ReduceSyms
             m_next_syms = case sa_sym sa of
               Sym (L _ (HsVar _ (L _ v))) -> if not $ v `elem` (var_ref_tail $ sa_stack sa)
-                then Just $
-                  (
+                then (
                       mconcat
                       -- . map (\rs' ->
                       --     let rss' = map (sub t) (rs_syms rs')
                       --     in map (uncurry (id )) (zip rss' (rs_syms rs')))
                       . map (\sa' ->
                           reduce_deep $ sa' {
-                            sa_stack = append_frame (VarRefFrame v) (sa_stack sa'),
-                            sa_args = (sa_args sa') <> next_args
+                            sa_stack = mapSB ((VarRefFrame v):) (sa_stack sa'),
+                            sa_args = (sa_args sa') <> (sa_args sa)
                           }
                         )
                     )
-                  <$> ((stbl_table t) !? v)
+                  <$> (t !? v)
                 else Nothing
-              _ -> Just Nothing
-        in fromMaybe mempty (fromMaybe (
-            if args_changed
-              then mempty { rs_syms = [sa { sa_args = next_args }] } -- `sa` is NF by assumption
-              else mempty -- encode the law that if all arguments have failed and the sym has also failed, this whole match fails
-          ) <$> m_next_syms) -- encode the law that if this is a var reduction cycle, then the result is empty -- implant the `sub`'d writes into the syms
+              _ -> Nothing
+        in snd ((t, sa), fromMaybe mempty m_next_syms)
       
-      iterant :: [Bind] -> PatMatchSyms -> (Bool, ([Bind], PatMatchSyms))
-      iterant binds' pms =
-        let next_pms = fromMaybe mempty $ mconcat $ map (mconcat . uncurry map . (pat_match_one *** rs_syms)) binds'
-            m_next_syms = map (map (sub (pms_syms next_pms)) . rs_syms) (map snd binds') -- [[ReduceSyms]]
-            next_binds = map
-              (\(next_rss, (prev_pat, prev_rs)) ->
-                  (prev_pat, (prev_rs <> mconcat next_rss) {
-                      rs_syms = concatMap (uncurry list_alt . (rs_syms *** pure)) (zip next_rss (rs_syms prev_rs))
-                    })
-                ) (zip m_next_syms binds') -- [([ReduceSyms], (Pat, ReduceSyms))]
-            
-            -- note that writes themselves are iterative: need to progressively dig writes out of the reduce cycle and substitute anything from this SymTable
-            next_writes = (\rs_ws -> unionsWith (++) $ M.map snd rs_ws : (map (rs_writes . fst) $ M.elems rs_ws))
-              $ M.map ((mconcat *** concat) . unzip . map (-- Map Pipe ([ReduceSyms], [[Write]])
-                  (\(sas, (rs, w)) -> (rs, map (\sa -> w { w_sym = sa }) sas))
-                  . (uncurry list_alt . (rs_syms *** pure . w_sym) &&& id)
-                  . (sub (pms_syms next_pms) . w_sym &&& id)
-                )
-              ) (unionWith (++) (pms_writes next_pms) (rs_writes $ mconcat $ mconcat m_next_syms))
-              
+      iterant :: PatMatchSyms -> (Bool, PatMatchSyms)
+      iterant pms =
+        -- BOOKMARK not working becuase of effed ordering of write substitution: should pass in PatMatchSyms and use the binds within the SymTable within that, so we can also substitute on writes
+        let f0 :: Data b => b -> Q ReduceSyms b
+            f0 b = Q $ Just (mempty, b)
+            next_table = pat_match_many (stbl_binds $ pms_syms pms) -- even if all the matches failed, we might've made new writes which might make some matches succeed
+            binder = everywhereWithContextBut (<>) (
+                  unQ . (
+                      f0
+                        `mkQT` (Q . Just . (mconcat *** concat) . unzip . map ((fst &&& uncurry list_alt . (rs_syms *** pure)) . (sub next_table &&& id)))
+                        `extQT` (const (Q Nothing) :: Stack -> Q ReduceSyms Stack)
+                    )
+              ) mempty
+            (next_rs, next_pms) = binder pms
         in (
-            (any (any (null . rs_syms)) m_next_syms) && (M.null next_writes),
-            (
-                next_binds,
-                next_pms {
-                  pms_writes = next_writes
-                } -- prefer new sym matches because it's purely progressive
-              )
+            null $ rs_syms next_rs,
+            next_pms {
+              pms_writes = rs_writes next_rs <> pms_writes next_pms
+            }
           )
-      syms0 = mconcat $ map snd binds
-      (bindsn, symsn) = snd $ until fst (uncurry iterant . snd) (False, (binds, mempty))
-       -- Map Pipe (ReduceSyms, [Write])
-  in symsn {
-      pms_syms = (pms_syms symsn) {
-        stbl_binds = bindsn
+      
+      (rs0, binds0) = first mconcat $ unzip $ map ((\(pat, rs) -> (rs, (pat, rs_syms rs))) . second (mconcat . map reduce_deep)) binds -- [(Pat, ReduceSyms)] => [(ReduceSyms, (Pat, [SymApp]))] => ([ReduceSyms], [(Pat, SymApp)])
+      (_, pmsn) = until fst (iterant . snd) (False, mempty {
+            pms_syms = mempty {
+              stbl_binds = binds0
+            }
+          })
+    in pmsn {
+      pms_syms = (pms_syms pmsn) {
+        stbl_table = pat_match_many (stbl_binds $ pms_syms pmsn)
       },
-      pms_writes = rs_writes syms0 <> pms_writes symsn
-    } -- BOOKMARK URGENT give the stbl_binds to all the pms_syms' stacks
+      pms_writes = pms_writes pmsn <> rs_writes rs0
+    }
 
 reduce :: ReduceSyms -> (Int, ReduceSyms)
 reduce syms0 =
@@ -205,7 +189,7 @@ reduce syms0 =
                            }] }
             expanded = mconcat $ case sa_sym sa of
               Sym (L _ (HsVar _ v)) -> case varString $ unLoc v of
-                "newEmptyMVar" -> fromMaybe mempty (map (expand_reads ws . w_sym) <$> ws !? make_stack_key sa) -- by only taking `w_sym`, encode the law that write threads are not generally the threads that read (obvious saying it out loud, but it does _look_ like we're losing information here)
+                "newEmptyMVar" -> fromMaybe mempty (map (expand_reads ws) <$> ws !? make_stack_key sa) -- by only taking `w_sym`, encode the law that write threads are not generally the threads that read (obvious saying it out loud, but it does _look_ like we're losing information here)
                 "readMVar" | length m_next_args > 0 -> head m_next_args -- list of pipes from the first arg
                 _ -> []
               _ -> []
@@ -217,25 +201,25 @@ reduce syms0 =
       
       iterant :: ReduceSyms -> (Bool, ReduceSyms)
       iterant rs =
-        let update_branch sa =
-              let (next_pms, next_branch) = (mconcat *** SB) $ unzip $ map (\case
+        let update_stack sa =
+              let (next_pms', next_stack) = (mconcat *** SB) $ unzip $ map (\case
                       af@(AppFrame { af_syms }) ->
-                        let next_binds = map (second (mconcat . map (expand_reads (rs_writes rs)) . rs_syms)) (stbl_binds af_syms)
-                            next_pms' = pat_match next_binds
-                        in (next_pms', af {
-                            af_syms = pms_syms next_pms'
+                        let (next_rs', next_binds) = (first mconcat) $ unzip $ map ((snd &&& second rs_syms) . second (mconcat . map (expand_reads (rs_writes rs)))) (stbl_binds af_syms)
+                            next_pms'' = pat_match next_binds
+                        in (next_pms'' {
+                            pms_writes = pms_writes next_pms'' <> rs_writes next_rs'
+                          }, af {
+                            af_syms = pms_syms next_pms''
                           })
                       v -> (mempty, v)
-                    ) (unSB $ st_branch $ sa_stack sa)
-                  (next_args_pms, next_args) = unzip $ map (unzip . map update_branch) (sa_args sa)
-              in (next_pms <> (mconcat $ mconcat next_args_pms), sa {
-                sa_stack = (sa_stack sa) {
-                  st_branch = next_branch
-                },
+                    ) (unSB $ sa_stack sa)
+                  (next_args_pms, next_args) = unzip $ map (unzip . map update_stack) (sa_args sa)
+              in (next_pms' <> (mconcat $ mconcat next_args_pms), sa {
+                sa_stack = next_stack,
                 sa_args = next_args
               })
               
-            (next_pms, next_rs) = (mconcat *** mconcat) $ unzip $ map (second (expand_reads (rs_writes rs)) . update_branch) $ rs_syms rs
+            (next_pms, next_rs) = (mconcat *** mconcat) $ unzip $ map (second (expand_reads (rs_writes rs)) . update_stack) $ rs_syms rs
             next_writes = (rs_writes next_rs) <> (pms_writes next_pms)
         in (M.null next_writes, next_rs {
             rs_writes = next_writes
@@ -248,7 +232,7 @@ reduce_deep :: SymApp -> ReduceSyms
 reduce_deep sa | let args = sa_args sa
                      sym = sa_sym sa
                , length args > 0 && is_zeroth_kind sym = error $ "Application on " ++ (show $ toConstr sym)
-reduce_deep sa@(SA consumers stack m_sym args) =
+reduce_deep sa@(SA consumers stack m_sym args thread) =
   -------------------
   -- SYM BASE CASE --
   -------------------
@@ -276,29 +260,30 @@ reduce_deep sa@(SA consumers stack m_sym args) =
       HsLamCase _ mg -> unravel1 (HsLam NoExt mg <$ sym) []
       
       HsLam _ mg | let loc = getLoc $ mg_alts mg -- <- NB this is why the locations of MatchGroups don't matter
-                 , not $ is_visited (st_branch stack) sa -> -- beware about `noLoc`s showing up here: maybe instead break out the pattern matching code
+                 , not $ is_visited stack sa -> -- beware about `noLoc`s showing up here: maybe instead break out the pattern matching code
                   if matchGroupArity mg > length args
                     then terminal
                     else
-                      let pat_matches =
-                            (unLoc $ mg_alts mg) & mconcat . mconcat . map ( -- over function body alternatives
-                              map ( -- over arguments
-                                mconcat . catMaybes . map ( -- over possible expressions
-                                  uncurry (flip pat_match_one) -- share the same stack
-                                ) . (uncurry zip) . (id *** repeat)
-                              ) . zip (sa_args sa) . map unLoc . m_pats . unLoc -- `args` FINALLY USED HERE
-                            ) -- NOTE no recursive pattern matching needed here because argument patterns are purely deconstructive and can't refer to the new bindings the others make
+                      let next_binds :: [Bind]
+                          next_binds = concatMap ( -- over function body alternatives
+                              flip zip (sa_args sa) . map unLoc . m_pats . unLoc -- `args` FINALLY USED HERE -- [[SymApp]] vs. [Pat]
+                            ) (unLoc $ mg_alts mg)
+                          next_pat_matches :: Map Id [SymApp]
+                          next_pat_matches = pat_match_many next_binds -- NOTE no recursive pattern matching needed here because argument patterns are purely deconstructive and can't refer to the new bindings the others make
                           
                           bind_pms@(PatMatchSyms {
                               pms_syms = next_explicit_binds,
                               pms_writes = bind_writes
-                            }) = pat_match $ grhs_binds (append_frame (AppFrame sa mempty) stack) mg -- STACK questionable: do we need the new symbol here? Shouldn't it be  -- localize binds correctly via pushing next stack location
+                            }) = pat_match $ grhs_binds mg -- STACK questionable: do we need the new symbol here? Shouldn't it be  -- localize binds correctly via pushing next stack location
                           next_exprs = grhs_exprs $ map (grhssGRHSs . m_grhss . unLoc) $ unLoc $ mg_alts mg
-                          next_frame = AppFrame sa (pms_syms pat_matches <> next_explicit_binds)
-                          next_stack = append_frame next_frame stack
+                          next_frame = AppFrame sa (SymTable {
+                              stbl_table = next_pat_matches,
+                              stbl_binds = next_binds
+                            } <> next_explicit_binds)
+                          next_stack = mapSB (next_frame:) stack
                           next_args = drop (matchGroupArity mg) args
                       in mempty {
-                        rs_writes = pms_writes bind_pms <> pms_writes pat_matches
+                        rs_writes = pms_writes bind_pms
                       }
                         <> (mconcat $ map (\next_expr ->
                             reduce_deep sa {
@@ -331,9 +316,7 @@ reduce_deep sa@(SA consumers stack m_sym args) =
               mconcat $ map (\sa' ->
                   reduce_deep sa' { -- TODO: check if `reduce_deep` is actually necessary here; might not be because we expect the symbols in the stack to be resolved
                     sa_args = sa_args sa' ++ args', -- ARGS good: elements in the stack are already processed, so if their args are okay these ones are okay
-                    sa_stack = (sa_stack sa') {
-                      st_branch = mapSB ((VarRefFrame v):) (st_branch (sa_stack sa'))
-                    }
+                    sa_stack = mapSB ((VarRefFrame v):) (sa_stack sa')
                   }
                 ) left_syms
              | otherwise -> case varString v of
@@ -365,11 +348,8 @@ reduce_deep sa@(SA consumers stack m_sym args) =
                         ) o
                 
               "forkIO" | to_fork:[] <- args' ->
-                  let result = mconcat $ map (\sa' -> reduce_deep sa' {
-                          sa_stack = stack {
-                            st_thread = (st_branch stack, st_branch $ sa_stack sa')
-                          }
-                        }) to_fork
+                  let this_thread = (getLoc sym, stack)
+                      result = mconcat $ map (everywhereBut (False `mkQ` (const True :: Stack -> Bool)) (mkT $ \sa' -> sa' { sa_thread = this_thread }) . reduce_deep) to_fork
                   in result {
                       rs_syms = [error "Using the ThreadID from forkIO is not yet supported."]
                     }
@@ -378,7 +358,7 @@ reduce_deep sa@(SA consumers stack m_sym args) =
                 then
                   let (pipes:vals:_) = args'
                       next_writes = map (\pipe -> case sa_sym pipe of
-                          Sym (L _ (HsVar _ v)) | varString (unLoc v) == "newEmptyMVar" -> singleton (make_stack_key pipe) $ map (\val -> Write (st_thread stack) val) vals
+                          Sym (L _ (HsVar _ v)) | varString (unLoc v) == "newEmptyMVar" -> singleton (make_stack_key pipe) vals
                           _ -> mempty
                         ) pipes
                   in terminal' { -- this is a bit silly atm since terminal writes are empty, but not necessarily all the time
@@ -404,12 +384,12 @@ reduce_deep sa@(SA consumers stack m_sym args) =
                               nf_arg1_syms = reduce_deep sa { sa_sym = Sym v, sa_args = [] }
                               arg0:args_rest = args
                           in case stack_var_lookup True (unLoc op) stack of
-                            Just branch_exprs ->
+                            Just stack_exprs ->
                               mappend nf_arg1_syms { rs_syms = [] } $ mconcat $ map (\sa' ->
                                 reduce_deep $ sa' {
                                   sa_args = (sa_args sa') ++ (arg0 : (rs_syms nf_arg1_syms) : args_rest) -- TODO also do the operator constructor case
                                 }
-                              ) branch_exprs
+                              ) stack_exprs
                             Nothing -> terminal
                         | otherwise -> error "Unsaturated (i.e. partial) SectionR is not yet supported."
           
@@ -419,13 +399,13 @@ reduce_deep sa@(SA consumers stack m_sym args) =
         let PatMatchSyms {
                 pms_syms = next_explicit_binds,
                 pms_writes = bind_writes
-              } = pat_match $ grhs_binds stack rhss
+              } = pat_match $ grhs_binds rhss
             next_exprs = grhs_exprs rhss
         in mempty { rs_writes = bind_writes }
           <> (mconcat $ map (\next_expr ->
               reduce_deep sa {
                 sa_sym = Sym next_expr,
-                sa_stack = (stack { st_branch = mapSB ((AppFrame sa next_explicit_binds):) (st_branch stack) })
+                sa_stack = mapSB ((AppFrame sa next_explicit_binds):) stack
               }) next_exprs) -- TODO check that record update with sym (and its location) is the right move here
         
       HsLet _ _ expr -> unravel1 expr [] -- assume local bindings already caught by surrounding function body (HsLam case)

--- a/src/Ra/GHC.hs
+++ b/src/Ra/GHC.hs
@@ -32,7 +32,7 @@ import Data.Map.Strict ( unionWith, unionsWith, insert, singleton, empty, fromLi
 import Control.Applicative ( liftA2 )
 
 import Ra ( pat_match, reduce_deep )
-import Ra.Lang -- ( Stack(..), SymApp(..), Sym(..), SymTable(..), PatMatchSyms(..), ReduceSyms(..), StackBranch(..), unSB, mapSB, union_sym_tables, make_stack_key )
+import Ra.Lang -- ( Stack(..), SymApp(..), Sym(..), SymTable(..), PatMatchSyms(..), ReduceSyms(..), Stack(..), unSB, mapSB, union_sym_tables, make_stack_key )
 import Ra.Extra
 
 unHsWrap :: LHsExpr GhcTc -> LHsExpr GhcTc
@@ -47,14 +47,11 @@ deapp expr =
     HsApp _ l r -> (id *** (++[r])) (deapp l)
     _ -> (unwrapped, [])
 
-bind_to_table :: Stack -> HsBind GhcTc -> [Bind]
-bind_to_table st b = case b of
+bind_to_table :: HsBind GhcTc -> [Bind]
+bind_to_table b = case b of
   AbsBinds { abs_exports, abs_binds } ->
-    let subbinds = mconcat $ bagToList $ mapBag (bind_to_table st . unLoc) abs_binds
-    in subbinds <> map (
-        VarPat NoExt . noLoc . abe_poly
-        &&& reduce_deep . ((flip (SA [] st)) []) . Sym . noLoc . HsVar NoExt . noLoc . abe_mono
-      ) abs_exports
+    let subbinds = mconcat $ bagToList $ mapBag (bind_to_table . unLoc) abs_binds -- consider making union_sym_table just Foldable t => ...
+    in subbinds <> map (VarPat NoExt . noLoc . abe_poly &&& pure . sa_from_sym . Sym . noLoc . HsVar NoExt . noLoc . abe_mono) abs_exports
     
   -- AbsBindsSig { abs_sig_export, abs_sig_bind = L _ abs_sig_bind } -> 
   --   let subbinds = bind_to_table stack abs_sig_bind
@@ -65,17 +62,11 @@ bind_to_table st b = case b of
   -------------------
   -- SYM BASE CASE --
   -------------------
-  FunBind { fun_id = fun_id, fun_matches } -> [(
-      VarPat NoExt fun_id,
-      reduce_deep (SA [] st (Sym $ noLoc $ HsLam NoExt fun_matches) [])
-    )]
+  FunBind { fun_id = fun_id, fun_matches } -> [( VarPat NoExt fun_id, [sa_from_sym (Sym $ noLoc $ HsLam NoExt fun_matches) ])]
   
   PatBind { pat_lhs = L _ pat_lhs, pat_rhs } ->
-    grhs_binds st pat_rhs <> [(
-        pat_lhs,
-        mconcat $ map (reduce_deep . flip (SA [] st) [] . Sym) (grhs_exprs pat_rhs)
-      )]
-  VarBind{} -> mempty
+    grhs_binds pat_rhs <> [(pat_lhs, map (sa_from_sym . Sym) (grhs_exprs pat_rhs))]
+  VarBind {} -> mempty
   _ -> error $ constr_ppr b
 
 -- gmapQ :: Data c => (forall d. Data d => d -> e) -> c -> [e]
@@ -83,12 +74,12 @@ bind_to_table st b = case b of
 grhs_exprs :: GenericQ [LHsExpr GhcTc]
 grhs_exprs x = map (\(L _ (GRHS _ _ body) :: LGRHS GhcTc (LHsExpr GhcTc)) -> body) (concat $ shallowest cast x)
 
-grhs_binds :: Stack -> GenericQ [Bind] -- TODO consider passing more info via `GenericQ (Maybe PatMatchSyms)`, and removing the fromMaybe
-grhs_binds st = everythingBut (<>) (
+grhs_binds :: GenericQ [Bind] -- TODO consider passing more info via `GenericQ (Maybe PatMatchSyms)`, and removing the fromMaybe
+grhs_binds = everythingBut (<>) (
     (mempty, False)
-    `mkQ` ((,True) . bind_to_table st)
+    `mkQ` ((,True) . bind_to_table)
     `extQ` ((,False) . ((\case
-        BindStmt _ (L _ pat) expr _ _ -> [(pat, reduce_deep (SA [] st (Sym expr) []))]
+        BindStmt _ (L _ pat) expr _ _ -> [(pat, [sa_from_sym (Sym expr)])] -- TODO check if a fresh stack key here is the right thing to do
         _ -> mempty
       ) . unLoc :: LStmt GhcTc (LHsExpr GhcTc) -> [Bind])) -- TODO dangerous: should we really keep looking deeper after finding a BindStmt?
     `extQ` ((mempty,) . ((\case 

--- a/src/Ra/GHC.hs
+++ b/src/Ra/GHC.hs
@@ -67,9 +67,7 @@ bind_to_table st b = case b of
   -------------------
   FunBind { fun_id = fun_id, fun_matches } -> [(
       VarPat NoExt fun_id,
-      mempty {
-        rs_syms = [SA [] st (Sym $ noLoc $ HsLam NoExt fun_matches) []]
-      }
+      reduce_deep (SA [] st (Sym $ noLoc $ HsLam NoExt fun_matches) [])
     )]
   
   PatBind { pat_lhs = L _ pat_lhs, pat_rhs } ->

--- a/src/Ra/GHC.hs-boot
+++ b/src/Ra/GHC.hs-boot
@@ -14,14 +14,14 @@ module Ra.GHC (
 import GHC
 import Data.Generics
 
-import Ra.Lang ( Sym, Stack, SymTable, PatMatchSyms, StackBranch, Bind )
+import Ra.Lang ( Sym, Stack, SymTable, PatMatchSyms, Bind )
 import Ra.Extra
 
 unHsWrap :: LHsExpr GhcTc -> LHsExpr GhcTc -- almost don't have to export this, except for legit use case for unwrapping `OpApp`s
 deapp :: LHsExpr GhcTc -> (LHsExpr GhcTc, [LHsExpr GhcTc])
-bind_to_table :: Stack -> HsBind GhcTc -> [Bind]
+bind_to_table :: HsBind GhcTc -> [Bind]
 grhs_exprs :: GenericQ [LHsExpr GhcTc]
-grhs_binds :: Stack -> GenericQ [Bind]
+grhs_binds :: GenericQ [Bind]
 mg_drop :: Int -> MatchGroup GhcTc (LHsExpr GhcTc) -> MatchGroup GhcTc (LHsExpr GhcTc)
 mg_flip :: MatchGroup GhcTc (LHsExpr GhcTc) -> MatchGroup GhcTc (LHsExpr GhcTc)
 varString :: Id -> String

--- a/src/Ra/Lang/Extra.hs
+++ b/src/Ra/Lang/Extra.hs
@@ -6,7 +6,6 @@ module Ra.Lang.Extra (
   ppr_rs,
   ppr_pms,
   ppr_stack,
-  ppr_branch,
   ppr_writes
 ) where
 
@@ -47,7 +46,7 @@ ppr_sa show' = go 0 where
           )
 
 ppr_writes :: Printer -> Writes -> String
-ppr_writes show' = concatMap ((++"\n---\n") . uncurry ((++) . (++" -> ")) . (show' *** concatMap ((++"\n") . ppr_sa show' . w_sym))) . assocs
+ppr_writes show' = concatMap ((++"\n---\n") . uncurry ((++) . (++" -> ")) . (show' *** concatMap ((++"\n") . ppr_sa show'))) . assocs
 
 -- ppr_hold :: Printer -> Hold -> String
 -- ppr_hold show' = uncurry ((++) . (++" <- ")) . (show' . h_pat &&& ppr_sa show' . h_sym)
@@ -66,23 +65,23 @@ ppr_pms show' = flip concatMap printers . (("\n===\n"++).) . flip ($) where
       , ppr_writes show' . pms_writes
     ]
 
-ppr_stack :: Printer -> Stack -> String
-ppr_stack show' =
-  show . map (\case
-      AppFrame { af_syms, af_raw } ->
-        ppr_sa show' af_raw
-        ++ ", "
-        ++ (show $ map (
-            uncurry ((++) . (++" -> ")) . (
-                show'
-                *** concat . intersperse "\n" . map (ppr_sa show')
-              )
-          ) (M.assocs $ stbl_table af_syms))
-      VarRefFrame v -> show' v
-    ) . unSB . st_branch
+-- ppr_stack :: Printer -> Stack -> String
+-- ppr_stack show' =
+--   show . map (\case
+--       AppFrame { af_syms, af_raw } ->
+--         ppr_sa show' af_raw
+--         ++ ", "
+--         ++ (show $ map (
+--             uncurry ((++) . (++" -> ")) . (
+--                 show'
+--                 *** concat . intersperse "\n" . map (ppr_sa show')
+--               )
+--           ) (M.assocs $ stbl_table af_syms))
+--       VarRefFrame v -> show' v
+--     ) . unSB
 
-ppr_branch :: Printer -> StackBranch -> String
-ppr_branch show' = foldr (\case
+ppr_stack :: Printer -> Stack -> String
+ppr_stack show' = foldr (\case
     AppFrame sa syms -> flip (foldr ((++) . (++"\n\n") . uncurry (++) . (((++", ") . show') *** concatMap (show' . sa_sym)))) (M.assocs $ stbl_table syms) . (++"---\n\n")
     _ -> id
   ) "" . unSB

--- a/src/Ra/Lang/Extra.hs
+++ b/src/Ra/Lang/Extra.hs
@@ -12,7 +12,7 @@ module Ra.Lang.Extra (
 import GHC ( LHsExpr, GhcTc )
 import Data.List ( intersperse )
 import Data.Bool ( bool )
-import Data.Tuple.Extra ( (&&&), (***) )
+import Data.Tuple.Extra ( (&&&), (***), both )
 
 import Ra.Lang
 
@@ -46,7 +46,7 @@ ppr_sa show' = go 0 where
           )
 
 ppr_writes :: Printer -> Writes -> String
-ppr_writes show' = concatMap ((++"\n---\n") . uncurry ((++) . (++" -> ")) . (show' *** concatMap ((++"\n") . ppr_sa show'))) . assocs
+ppr_writes show' = concatMap ((++"\n---\n") . uncurry ((++) . (++" -> ")) . (both $ concatMap ((++"\n") . ppr_sa show')))
 
 -- ppr_hold :: Printer -> Hold -> String
 -- ppr_hold show' = uncurry ((++) . (++" <- ")) . (show' . h_pat &&& ppr_sa show' . h_sym)
@@ -62,6 +62,7 @@ ppr_pms :: Printer -> PatMatchSyms -> String
 ppr_pms show' = flip concatMap printers . (("\n===\n"++).) . flip ($) where
   printers = [
       concatMap ((++"\n") . uncurry ((++) . (++" -> ")) . (show' *** concatMap ((++"\n") . ppr_sa show'))) . assocs . stbl_table . pms_syms
+      , concatMap ((++"\n") . uncurry ((++) . (++" -> ")) . (show' *** concatMap (ppr_sa show'))) . stbl_binds . pms_syms
       , ppr_writes show' . pms_writes
     ]
 

--- a/target/H.hs
+++ b/target/H.hs
@@ -12,7 +12,7 @@ foo = do
   v <- newEmptyMVar
   w <- newEmptyMVar
   _ <- putMVar w (v, 42)
-  _ <- putMVar v x
+  _ <- putMVar v y
   (p, _) <- readMVar w -- resolving from the wrong stack: may be from hold flagging (one breakpoint surprisingly not hit). OHHHHH. This is a fundamental flaw with the pattern matching scheme, which matches against only previous symbols, not symbols in the same group (thanks to `letrec`). Crap. BOOKMARK
   readMVar p
 

--- a/target/H.hs
+++ b/target/H.hs
@@ -8,7 +8,7 @@ type Consumer a b = a -> b
 foo :: IO Int
 foo = do
   let x = 42
-      y = x
+      y = bar x
   v <- newEmptyMVar
   w <- newEmptyMVar
   _ <- putMVar w (v, 42)

--- a/target/J.hs
+++ b/target/J.hs
@@ -1,8 +1,11 @@
 module J where
   import Control.Concurrent.MVar
+  type Consumer x = x -> x
   
   foo = do
-    v <- newEmptyMVar
-    putMVar v ((), 42)
-    b <- readMVar v
-    return b
+    x <- newEmptyMVar
+    _ <- putMVar x (bar 42)
+    readMVar x
+  
+  bar :: Consumer a
+  bar x = x


### PR DESCRIPTION
This PR wraps up stage 2 alpha development, with the broad strokes in place of:

- Where `SymApp`s are reduced and why
- Exact responsibilities of `pat_match`, `reduce` and `reduce_deep`
- Correct stack, argument, expression and consumer propagation for `SymApp`
- Correct write and sym propagation for sym collections `PatMatchSyms` and `ReduceSyms`
- Correct contents of the `Stack`, which is now defined as:
  1. A collection of `AppFrame`s (function calls, including the original invokation with args for cycle detection) and `VarRefFrame`s (cycle detection for HsVar dereferencing)
  2. ...that only stores argument bindings from reducing a saturated HsLam

  This is possible because `pat_match` is now responsible for replacing all symbols for a given binding scope, and the recursive application of `pat_match` will ensure the only names remaining are argument bindings and unknown names.

Test file `target/H.hs` is the most advanced correct behavior to date, showing pure code handling, distinguishing multiple writes, pattern matching piped values, and higher-order pipes.