### PR TITLE
Repair pat_match and expand_reads treatments of more exotic pipes

### DIFF
--- a/src/Ra.hs
+++ b/src/Ra.hs
@@ -175,7 +175,7 @@ pat_match binds =
                       )
                     `extQT` ((mempty,) :: Stack -> ([[DoStmt]], Stack))
                   )
-        dig' _ = undefined
+        dig' _ = (mempty,)
         
         reloc :: SymApp -> SymApp -> SymApp
         reloc sa sa' =

--- a/src/Ra/Impure.hs
+++ b/src/Ra/Impure.hs
@@ -9,7 +9,7 @@ import GHC
 
 import Data.Maybe ( catMaybes, fromMaybe, fromJust )
 import Data.Generics ( Data, Typeable, mkQ )
-import Data.Generics.Extra ( everywhereWithContextBut, everywhereWithContextLazyBut, mkQT, extQT )
+import Data.Generics.Extra ( everywhereWithContextBut, everywhereWithContextLazyBut, mkQT, extQT, gmapQT, GenericQT )
 import Control.Arrow ( (&&&), (***), first, second )
 
 import Ra ( reduce_deep, pat_match, and_pat_match_many )
@@ -76,7 +76,7 @@ refresh_frames ws sa =
                 -- outside of generic query because otherwise it'll cause infinite
                 -- recursion, and `extQT` was even more awkward
                 
-                let next_binds = snd (sa, map (second (expand_reads ws)) (stbl_binds bf_syms))
+                let next_binds = snd (sa, map (second (concatMap (expand_reads ws))) (stbl_binds bf_syms)) -- DEBUG
                     next_pms = pat_match next_binds
                 in (next_pms, BindFrame (pms_syms next_pms))
               _ -> (mempty, frame)
@@ -119,25 +119,24 @@ reduce syms0 =
       iterant stmts =
         let writes = catMaybes $ map mk_write stmts
             f0 = (mempty,)
-            (next_stmts, next_rs) = everywhereWithContextLazyBut
-                (<>)
-                (False `mkQ` (\case { BindFrame {} -> True; _ -> False } :: StackFrame -> Bool))
-                (
-                    f0
-                    `mkQT` (\sas ->
-                        (mconcat *** concat)
-                        $ unzip
-                        $ map (\sa ->
-                            let (next_pms, next_sa) = refresh_frames writes sa -- re-pat-match the bindings 
-                                next_rs = reduce_deep $ next_sa
-                            in (
-                                pms_stmts next_pms <> rs_stmts next_rs,
-                                rs_syms next_rs
-                              )
+            go :: GenericQT [DoStmt]
+            go = first mconcat . (
+                gmapQT go
+                `mkQT` (
+                    (\(st0, (st1, sas)) -> (st0 <> st1, sas))
+                    . second (mconcat . map (\sa ->
+                        let (next_pms, next_sa) = refresh_frames writes sa -- re-pat-match the bindings 
+                            next_rs = reduce_deep $ next_sa
+                        in (
+                            [pms_stmts next_pms, rs_stmts next_rs],
+                            concatMap (expand_reads writes) (rs_syms next_rs)
                           )
-                        $ expand_reads writes sas -- DEBUG
-                      )
-                  ) mempty syms0
+                      ))
+                    . gmapQT go
+                  )
+                `extQT` ((\fr -> case fr of { BindFrame {} -> f0 fr; _ -> gmapQT go fr }) :: StackFrame -> ([[DoStmt]], StackFrame))
+              )
+            (next_stmts, next_rs) = go syms0
         in (writes, next_rs {
           rs_stmts = rs_stmts next_rs <> next_stmts
         })
@@ -158,43 +157,45 @@ in if sa_loc sa `elem` map fst reads && sa_loc sa' `elem` map snd reads
   else ([(sa_loc sa, sa_loc sa')], nf_sas)
 -}
 
-expand_reads :: [Write] -> [SymApp] -> [SymApp]
-expand_reads ws = mconcat . map (\sa ->
-  let next_read_syms
-        | arg0:rest <- sa_args sa = mconcat $ map (\sa' ->
-            case sa_sym sa' of
-              Sym (L _ (HsVar _ (L _ v')))
-                | varString v' `elem` [
-                    "newMVar", -- DEBUG
-                    "newEmptyMVar",
-                    "newTVar",
-                    "newTVarIO",
-                    "newIORef",
-                    "newSTRef"
-                  ] -> unref ws (sa' { sa_args = rest })
-                | otherwise -> [sa']
-          ) arg0
-        | otherwise = [sa]
-    in case sa_sym sa of
-      Sym (L _ (HsVar _ (L _ v))) ->
-        if | varString v `elem` [
-              "readIORef",
-              "readMVar",
-              "takeMVar",
-              "readTVar",
-              "readTVarIO",
-              "readSTRef",
-              
-              "atomicSwapIORef"
-            ]
-           -> next_read_syms
-           
-           | varString v == "atomicModifyIORefLazy_"
-           -> map (\sa -> sa {
-              sa_sym = TupleConstr (getSymLoc $ sa_sym sa),
-              sa_args = [[sa], [sa]]
-            }) next_read_syms
-           
-           | otherwise -> [sa]
-      _ -> [sa]
-  )
+expand_reads :: [Write] -> SymApp -> [SymApp]
+expand_reads = expand_reads' 0 where
+  expand_reads' n ws sa
+    | n < sum (map (length . fst) ws) = -- reeeeeeeally crude upper bound for now
+      let next_read_syms
+            | arg0:rest <- sa_args sa = mconcat $ map (\sa' ->
+                case sa_sym sa' of
+                  Sym (L _ (HsVar _ (L _ v')))
+                    | varString v' `elem` [
+                        "newMVar", -- DEBUG
+                        "newEmptyMVar",
+                        "newTVar",
+                        "newTVarIO",
+                        "newIORef",
+                        "newSTRef"
+                      ] -> concatMap (expand_reads' (n + 1) ws) $ unref ws (sa' { sa_args = rest })
+                    | otherwise -> [sa']
+              ) arg0
+            | otherwise = [sa]
+      in case sa_sym sa of
+        Sym (L _ (HsVar _ (L _ v))) ->
+          if | varString v `elem` [
+                "readIORef",
+                "readMVar",
+                "takeMVar",
+                "readTVar",
+                "readTVarIO",
+                "readSTRef",
+                
+                "atomicSwapIORef"
+              ]
+             -> snd (sa, next_read_syms) -- DEBUG
+             
+             | varString v == "atomicModifyIORefLazy_"
+             -> map (\sa -> sa {
+                sa_sym = TupleConstr (getSymLoc $ sa_sym sa),
+                sa_args = [[sa], [sa]]
+              }) next_read_syms
+             
+             | otherwise -> [sa]
+        _ -> [sa]
+    | otherwise = [sa]

--- a/src/Ra/Impure.hs
+++ b/src/Ra/Impure.hs
@@ -7,12 +7,12 @@ module Ra.Impure (
 
 import GHC
 
-import Data.Maybe ( catMaybes, fromMaybe )
-import Data.Generics ( Data, Typeable )
-import Data.Generics.Extra ( everywhereWithContextBut, mkQT, extQT )
+import Data.Maybe ( catMaybes, fromMaybe, fromJust )
+import Data.Generics ( Data, Typeable, mkQ )
+import Data.Generics.Extra ( everywhereWithContextBut, everywhereWithContextLazyBut, mkQT, extQT )
 import Control.Arrow ( (&&&), (***), first, second )
 
-import Ra ( reduce_deep, pat_match )
+import Ra ( reduce_deep, pat_match, and_pat_match_many )
 import Ra.Lang
 import Ra.Extra
 import Ra.GHC.Util ( varString )
@@ -56,15 +56,32 @@ mk_write sa | Sym (L _ (HsVar _ (L _ v))) <- sa_sym sa =
              | otherwise = mempty
 
 
-refresh_app_frames :: Stack -> (PatMatchSyms, Stack)
-refresh_app_frames st = first mconcat $ unzip $ map (\frame -> case frame of
-    AppFrame {} ->
-      let next_pms = pat_match $ stbl_binds $ af_syms frame
-      in (next_pms, frame {
-        af_syms = pms_syms next_pms
-      })
-    _ -> (mempty, frame)
-  ) st
+refresh_frames :: Writes -> SymApp -> (PatMatchSyms, SymApp)
+refresh_frames ws sa =
+  let (next_pms, next_stack) =
+        first mconcat $ unzip $ map (\frame ->
+            case frame of
+              AppFrame { af_syms } ->
+                (mempty,
+                    if not $ null $ stbl_binds af_syms
+                      then frame {
+                          af_syms = af_syms {
+                            stbl_table = fromJust $ and_pat_match_many $ stbl_binds af_syms -- fromJust <= changes can't regress on these binds: only make it more likely to bind. If this AppFrame exists, it must have succeeded the first time at least
+                          }
+                        }
+                      else frame
+                  )
+              BindFrame { bf_syms } ->
+                -- Note: forces argument ws a bit awkwardly; needs its own handler
+                -- outside of generic query because otherwise it'll cause infinite
+                -- recursion, and `extQT` was even more awkward
+                
+                let next_binds = snd (sa, map (second (expand_reads ws)) (stbl_binds bf_syms))
+                    next_pms = pat_match next_binds
+                in (next_pms, BindFrame (pms_syms next_pms))
+              _ -> (mempty, frame)
+          ) (sa_stack sa) -- DEBUG
+  in (next_pms, sa { sa_stack = next_stack })
 
 unref :: Writes -> SymApp -> [SymApp]
 unref ws sa =
@@ -78,7 +95,7 @@ unref ws sa =
                   GT -> (,sas)
                   EQ -> (,sas <> next_sas)
                   LT -> (,next_sas)
-                ) $ compare max_len sa')
+                ) $ compare max_len sa') -- DEBUG
                 (snd ((sa, pipes), m_next_max_len)) -- DEBUG
                 <*> fmap (max max_len) m_next_max_len
           in if | elem (getSymLoc $ sa_sym sa) $ map (getSymLoc . sa_sym) pipes
@@ -93,8 +110,6 @@ unref ws sa =
 
 
 type WriteSite = (Stack, Stack) -- pipe and value locations
-newtype Q a b = Q (Maybe (a, b)) deriving (Data, Typeable)
-unQ (Q z) = z
 
 permute2 = concatMap (\(pipes, syms) -> [(pipe, sym) | pipe <- pipes, sym <- syms]) -- TODO stopgap before implementing Map
 
@@ -103,23 +118,26 @@ reduce syms0 =
   let iterant :: [DoStmt] -> (Writes, ReduceSyms) -- always act on syms0, return what we get on this phase
       iterant stmts =
         let writes = catMaybes $ map mk_write stmts
-            (next_stmts, next_rs) = everywhereWithContextBut (<>) (unQ . (
-                (Q . Just . (mempty,))
-                `mkQT` (Q . Just . (\sa ->
-                    (mconcat *** concat)
-                    $ unzip
-                    $ map (\sa ->
-                        let (next_pms, next_stack) = refresh_app_frames $ sa_stack sa -- re-pat-match the bindings 
-                            next_rs = reduce_deep $ sa { sa_stack = next_stack }
-                        in (
-                            pms_stmts next_pms <> rs_stmts next_rs,
-                            rs_syms next_rs
+            f0 = (mempty,)
+            (next_stmts, next_rs) = everywhereWithContextLazyBut
+                (<>)
+                (False `mkQ` (\case { BindFrame {} -> True; _ -> False } :: StackFrame -> Bool))
+                (
+                    f0
+                    `mkQT` (\sas ->
+                        (mconcat *** concat)
+                        $ unzip
+                        $ map (\sa ->
+                            let (next_pms, next_sa) = refresh_frames writes sa -- re-pat-match the bindings 
+                                next_rs = reduce_deep $ next_sa
+                            in (
+                                pms_stmts next_pms <> rs_stmts next_rs,
+                                rs_syms next_rs
+                              )
                           )
+                        $ expand_reads writes sas -- DEBUG
                       )
-                    $ expand_reads writes sa
-                  ))
-                `extQT` (const (Q Nothing) :: Stack -> Q [DoStmt] Stack) -- TODO URGENT it is probably not correct to skip replacement into the stack: we also have to substitute bindings in there in case they need to match. However, the knotted table is going to be tricky: will need to totally reknot the table, which might be done by PMS?
-              )) mempty syms0
+                  ) mempty syms0
         in (writes, next_rs {
           rs_stmts = rs_stmts next_rs <> next_stmts
         })

--- a/src/Ra/Lang/Extra.hs
+++ b/src/Ra/Lang/Extra.hs
@@ -6,7 +6,8 @@ module Ra.Lang.Extra (
   ppr_rs,
   ppr_pms,
   ppr_stack,
-  ppr_table
+  ppr_table,
+  ppr_binds
   -- ppr_writes
 ) where
 
@@ -87,8 +88,14 @@ ppr_pms show' = flip concatMap printers . (("\n===\n"++).) . flip ($) where
 --       VarRefFrame v -> show' v
 --     )
 
+ppr_binds :: Printer -> [Bind] -> String
+ppr_binds show' = unlines . map (uncurry (++) . ((++" -> ") . show' *** concat . intersperse ", " . map (ppr_sa show')))
+
 ppr_table :: Printer -> SymTable -> String
-ppr_table show' = foldr ((++) . (++"\n\n") . uncurry (++) . (((++", ") . show') *** concatMap (show' . sa_sym))) "" . M.assocs . stbl_table
+ppr_table show' = uncurry (++) . (
+    foldr ((++) . (++"\n\n") . uncurry (++) . (((++", ") . show') *** concatMap (show' . sa_sym))) "" . M.assocs . stbl_table
+    &&& ppr_binds show' . stbl_binds
+  )
 
 ppr_stack :: Printer -> Stack -> String
 ppr_stack show' = foldr (\case

--- a/target/T.hs
+++ b/target/T.hs
@@ -5,12 +5,14 @@ module T where
   
   bot x = bot x
   bar = do
-    let v = newEmptyMVar
-    v0 <- v
-    v1 <- v
-    putMVar v0 42
+    let bar _ = newEmptyMVar
+    v0 <- bar ()
+    v1 <- bar ()
+    putMVar v1 1
+    r1 <- readMVar v1
     r0 <- readMVar v0
-    putMVar v0 r0
+    putMVar v0 r1
+    putMVar v1 r0
     readMVar v0
   
   -- newtype Roll a = Roll (Roll a -> a)

--- a/target/U.hs
+++ b/target/U.hs
@@ -3,7 +3,8 @@ module U where
 import Control.Concurrent.MVar
 
 foo = do
-  v <- newEmptyMVar
+  let bar _ = newEmptyMVar
+  v <- bar ()
   putMVar v (0, 1)
   (a, _) <- readMVar v
   return a


### PR DESCRIPTION
This featureset contributes:

1. Distinguishing between pipe constructors that come from the monadic execution of an alias or function, no longer requiring than requiring pipe constructors be inlined in monadic chains
2. Recursive read expansion to track arbitrary paths of values into and out of pipes.